### PR TITLE
fix(android): ensure ready notifications are delivered on Android clients

### DIFF
--- a/packages/happy-app/sources/sync/sync.ts
+++ b/packages/happy-app/sources/sync/sync.ts
@@ -216,9 +216,8 @@ class Sync {
         this.openClawMachinesSync = new InvalidateSync(this.fetchOpenClawMachines);
 
         const registerPushToken = async () => {
-            if (__DEV__) {
-                return;
-            }
+            // Keep push token registration enabled in dev builds too:
+            // Android contributors often validate notifications on dev clients.
             await this.registerPushToken();
         }
         this.pushTokenSync = new InvalidateSync(registerPushToken);

--- a/packages/happy-cli/src/api/pushNotifications.ts
+++ b/packages/happy-cli/src/api/pushNotifications.ts
@@ -181,6 +181,7 @@ export class PushNotificationClient {
                         title,
                         body,
                         data,
+                        channelId: 'default',
                         sound: 'default',
                         priority: 'high',
                         badge: badgeCount


### PR DESCRIPTION
## Summary
- enable push token registration in dev client builds (remove __DEV__ short-circuit in app sync init)
- explicitly set Expo push channelId to default when CLI sends notifications

## Why
Android users reported no notification when a session completes. This patch keeps the change minimal while improving delivery reliability for the existing ready push flow.

## Verification
- code-path verification for token registration + push payload generation
- typecheck was not run in this environment because dependency installation repeatedly failed due network/cache fetch errors