### PR TITLE
fix(voice): add libglib2.0-0 to Dockerfile for @livekit/rtc-node on Linux

### DIFF
--- a/packages/happy-voice/Dockerfile
+++ b/packages/happy-voice/Dockerfile
@@ -4,7 +4,7 @@ ENV NODE_ENV=production
 WORKDIR /app
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends ca-certificates \
+    && apt-get install -y --no-install-recommends ca-certificates libglib2.0-0 \
     && update-ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Summary

Fix Docker build for happy-voice — `@livekit/rtc-node` requires `libgio-2.0.so.0` which is missing from `node:22-slim`, causing `ERR_DLOPEN_FAILED` at container startup.

```
happy-voice-1  | Node.js v22.22.2
happy-voice-1  | info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
happy-voice-1  | error Command failed with exit code 1.
happy-voice-1 exited with code 1 (restarting)
happy-voice-1  | yarn run v1.22.22
happy-voice-1  | $ tsx sources/main.ts all
happy-voice-1  | node:internal/modules/cjs/loader:1864
happy-voice-1  |   return process.dlopen(module, path.toNamespacedPath(filename));
happy-voice-1  |                  ^
happy-voice-1  |
happy-voice-1  | Error: libgio-2.0.so.0: cannot open shared object file: No such file or directory
happy-voice-1  |     at Object..node (node:internal/modules/cjs/loader:1864:18)
happy-voice-1  |     at Module.load (node:internal/modules/cjs/loader:1441:32)
happy-voice-1  |     at Function._load (node:internal/modules/cjs/loader:1263:12)
happy-voice-1  |     at TracingChannel.traceSync (node:diagnostics_channel:328:14)
happy-voice-1  |     at wrapModuleLoad (node:internal/modules/cjs/loader:237:24)
happy-voice-1  |     at Module.require (node:internal/modules/cjs/loader:1463:12)
happy-voice-1  |     at require (node:internal/modules/helpers:147:16)
happy-voice-1  |     at Object.<anonymous> (/app/node_modules/@livekit/rtc-node/dist/napi/native.cjs:203:31)
happy-voice-1  |     at Module._compile (node:internal/modules/cjs/loader:1705:14)
happy-voice-1  |     at Object.transformer (/app/node_modules/tsx/dist/register-D46fvsV_.cjs:3:1104) {
happy-voice-1  |   code: 'ERR_DLOPEN_FAILED'
happy-voice-1  | }
happy-voice-1  |
happy-voice-1  | Node.js v22.22.2
happy-voice-1  | error Command failed with exit code 1.
happy-voice-1  | info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
happy-voice-1 exited with code 1 (restarting)
```

## Changes

- Added `libglib2.0-0` to the `apt-get install` step in `packages/happy-voice/Dockerfile`

## Testing

How was this tested?

- [x] Tested locally
- [x] Existing tests pass
- [x] New tests added (if applicable)

## Related issues

Closes #
