### PR TITLE
fix(profile): allow GitHub name to be nullable

### DIFF
--- a/packages/happy-app/sources/sync/profile.ts
+++ b/packages/happy-app/sources/sync/profile.ts
@@ -7,7 +7,7 @@ import * as z from 'zod';
 export const GitHubProfileSchema = z.object({
     id: z.number(),
     login: z.string(),
-    name: z.string(),
+    name: z.string().nullable(),
     avatar_url: z.string(),
     email: z.string().nullable(),
     bio: z.string().nullable()


### PR DESCRIPTION
## Summary

修复 GitHub 用户资料解析失败的问题。当 GitHub 用户未设置显示名称时，API 返回 name: null，导致 Zod schema 校验失败。

## Changes

- 修改 GitHubProfileSchema，将 name 字段从 z.string() 改为 z.string().nullable()
- 与 email 和 bio 字段保持一致的 nullable 策略

## Testing

- [x] Tested locally - 类型检查通过 (yarn typecheck)
- [x] Existing tests pass
- [ ] New tests added (if applicable)

## Related issues

Closes #