### PR TITLE
fix(notification): fix Android push delivery and add error/rate-limit notifications

### DIFF
--- a/packages/happy-cli/src/api/apiSession.ts
+++ b/packages/happy-cli/src/api/apiSession.ts
@@ -884,6 +884,14 @@ export class ApiSessionClient extends EventEmitter {
     }
 
     /**
+     * Ask the server to push a notification to the user's devices.
+     * Used for error and rate-limit events that happen while the app is backgrounded.
+     */
+    sendSessionNotify(type: 'session_error' | 'rate_limit', message?: string) {
+        this.socket.emit('session-notify', { sid: this.sessionId, type, message });
+    }
+
+    /**
      * Send a generic usage report to the server for any provider
      */
     sendUsageReport(report: { key: string; tokens: { total: number; [key: string]: number }; cost: { total: number; [key: string]: number } }) {

--- a/packages/happy-cli/src/api/pushNotifications.ts
+++ b/packages/happy-cli/src/api/pushNotifications.ts
@@ -184,7 +184,8 @@ export class PushNotificationClient {
                         channelId: 'default',
                         sound: 'default',
                         priority: 'high',
-                        badge: badgeCount
+                        badge: badgeCount,
+                        channelId: 'default',
                     }
                 })
 

--- a/packages/happy-cli/src/api/types.ts
+++ b/packages/happy-cli/src/api/types.ts
@@ -120,6 +120,7 @@ export interface ClientToServerEvents {
     mode?: 'local' | 'remote';
   }) => void
   'session-end': (data: { sid: string, time: number }) => void,
+  'session-notify': (data: { sid: string, type: 'session_error' | 'rate_limit', message?: string }) => void,
   'update-metadata': (data: { sid: string, expectedVersion: number, metadata: string }, cb: (answer: {
     result: 'error'
   } | {

--- a/packages/happy-cli/src/claude/claudeRemoteLauncher.ts
+++ b/packages/happy-cli/src/claude/claudeRemoteLauncher.ts
@@ -217,9 +217,11 @@ export async function claudeRemoteLauncher(session: Session): Promise<'switch' |
                 } else if (errors && errors.length > 0) {
                     const errorText = errors.join('\n');
                     session.client.sendSessionEvent({ type: 'message', message: `Error: ${errorText}` });
+                    session.client.sendSessionNotify('session_error', errorText);
                     logger.debug('[remote]: sent error_during_execution as session event', { errorCount: errors.length });
                 } else {
                     session.client.sendSessionEvent({ type: 'message', message: 'An error occurred during execution' });
+                    session.client.sendSessionNotify('session_error', 'An error occurred during execution');
                 }
             }
             // Result messages don't need further processing (not part of conversation log)

--- a/packages/happy-cli/src/codex/runCodex.ts
+++ b/packages/happy-cli/src/codex/runCodex.ts
@@ -1143,6 +1143,8 @@ export async function runCodex(opts: {
                 } else if (!isUserAbort) {
                     messageBuffer.addMessage('Process exited unexpectedly', 'status');
                     session.sendSessionEvent({ type: 'message', message: 'Process exited unexpectedly' });
+                    const isRateLimit = errMsg.toLowerCase().includes('rate limit') || errMsg.includes('429');
+                    session.sendSessionNotify(isRateLimit ? 'rate_limit' : 'session_error', errMsg);
                     // Store session for potential recovery
                     if (backend && backend.isAlive) {
                         storedSessionIdForResume = backend.getSessionId();

--- a/packages/happy-cli/src/gemini/runGemini.ts
+++ b/packages/happy-cli/src/gemini/runGemini.ts
@@ -1466,6 +1466,9 @@ export async function runGemini(opts: {
             type: 'message',
             message: errorMsg,
           });
+          // Push notification to user's device
+          const isRateLimit = errorMsg.includes('rate limit') || errorMsg.includes('quota') || errorMsg.includes('RESOURCE_EXHAUSTED');
+          session.sendSessionNotify(isRateLimit ? 'rate_limit' : 'session_error', errorMsg);
         }
       } finally {
         // Reset permission handler, reasoning processor, and diff processor after turn (like Codex)

--- a/packages/happy-server/sources/app/api/socket/sessionUpdateHandler.ts
+++ b/packages/happy-server/sources/app/api/socket/sessionUpdateHandler.ts
@@ -219,10 +219,10 @@ export function sessionUpdateHandler(userId: string, socket: Socket, connection:
                     });
                 });
 
-                // Check notification stability and send push if ready
-                // This ensures push is only sent when the conversation is truly complete
+                // Turn ended — notify user that the session has completed.
+                // Server-driven (Method A): no client heartbeat dependency.
                 const notificationMgr = getNotificationManager();
-                await notificationMgr.checkAndNotify(sid);
+                await notificationMgr.notifyCompleted(sid);
             }
 
             // Emit session activity update to owner and shared users
@@ -591,6 +591,34 @@ export function sessionUpdateHandler(userId: string, socket: Socket, connection:
             });
         } catch (error) {
             log({ module: 'websocket', level: 'error' }, `Error in session-end: ${error}`);
+        }
+    });
+
+    // CLI signals an error or rate-limit so the server can push a notification
+    // to the user's device even when the app is backgrounded.
+    socket.on('session-notify', async (data: {
+        sid: string;
+        type: 'session_error' | 'rate_limit';
+        message?: string;
+    }) => {
+        try {
+            const { sid, type, message } = data ?? {};
+            if (!sid || !type) return;
+
+            // Only session-scoped CLI connections may send this
+            if (connection.connectionType !== 'session-scoped' || connection.sessionId !== sid) return;
+
+            const session = await db.session.findUnique({ where: { id: sid, accountId: userId }, select: { id: true } });
+            if (!session) return;
+
+            const notificationMgr = getNotificationManager();
+            if (type === 'rate_limit') {
+                await notificationMgr.notifyRateLimit(sid);
+            } else if (type === 'session_error') {
+                await notificationMgr.notifyError(sid, message ?? '执行过程中发生错误');
+            }
+        } catch (error) {
+            log({ module: 'websocket', level: 'error' }, `Error in session-notify: ${error}`);
         }
     });
 

--- a/packages/happy-server/sources/app/api/socket/sessionUpdateHandler.ts
+++ b/packages/happy-server/sources/app/api/socket/sessionUpdateHandler.ts
@@ -2,6 +2,7 @@ import { sessionAliveEventsCounter, websocketEventsCounter } from "@/app/monitor
 import { activityCache } from "@/app/presence/sessionCache";
 import { updateThinkingState } from "@/app/presence/sessionTurnRuntime";
 import { dispatchNextPendingIfPossible } from "@/app/session/pendingMessageAutoDispatch";
+import { getNotificationManager } from "@/app/session/NotificationManager";
 import { buildMessageDeliveryClearedEphemeral, buildMessageDeliveryErrorEphemeral, buildMessageErrorEphemeral, buildMessageSyncingEphemeral, buildMessageSyncedEphemeral, buildNewMessageUpdate, buildSessionActivityEphemeral, buildUpdateSessionUpdate, ClientConnection, eventRouter } from "@/app/events/eventRouter";
 import { db } from "@/storage/db";
 import { allocateSessionSeq } from "@/storage/seq";
@@ -217,6 +218,11 @@ export function sessionUpdateHandler(userId: string, socket: Socket, connection:
                         sessionId: sid,
                     });
                 });
+
+                // Check notification stability and send push if ready
+                // This ensures push is only sent when the conversation is truly complete
+                const notificationMgr = getNotificationManager();
+                await notificationMgr.checkAndNotify(sid);
             }
 
             // Emit session activity update to owner and shared users

--- a/packages/happy-server/sources/app/presence/sessionTurnRuntime.ts
+++ b/packages/happy-server/sources/app/presence/sessionTurnRuntime.ts
@@ -28,7 +28,7 @@ function ensureSessionState(sessionId: string): SessionTurnState {
         thinking: false,
         awaitingTurnStart: false,
         dispatching: false,
-        lastHeartbeatAt: 0,
+        lastHeartbeatAt: Date.now(),
     };
     runtimeBySession.set(sessionId, created);
     return created;

--- a/packages/happy-server/sources/app/session/ConversationSession.ts
+++ b/packages/happy-server/sources/app/session/ConversationSession.ts
@@ -1,0 +1,198 @@
+import { log } from "@/utils/log";
+
+/**
+ * Conversation state types for tracking session lifecycle.
+ * Used to determine when push notifications are safe to send.
+ */
+export type ConversationStatus = 'idle' | 'thinking' | 'executing_tool' | 'completed';
+
+export interface ConversationState {
+    conversationId: string;
+    status: ConversationStatus;
+    isThinking: boolean;
+    toolsInProgress: string[];
+    lastActivityTime: number;
+    messageCount: number;
+    toolsCompleted: number;
+    timeoutDetected: boolean;
+}
+
+/**
+ * ConversationSession tracks the state of a conversation for notification stability.
+ * 
+ * It monitors:
+ * - isThinking: whether the AI model is currently processing
+ * - toolsInProgress: tools that are currently being executed
+ * - lastActivityTime: timestamp of the last activity
+ * - status: current status of the conversation
+ * 
+ * The session is considered "ready for notification" when:
+ * - isThinking === false
+ * - toolsInProgress is empty
+ * - lastActivityTime is > 2 seconds ago (stability window)
+ * - status is 'completed' or 'idle'
+ * - timeoutDetected is false
+ */
+export class ConversationSession {
+    private state: {
+        conversationId: string;
+        isThinking: boolean;
+        toolsInProgress: Map<string, boolean>;
+        lastActivityTime: number;
+        status: ConversationStatus;
+        messageCount: number;
+        toolsCompleted: number;
+    };
+
+    private readonly TIMEOUT_THRESHOLD_MS = 30_000; // 30 seconds
+    private readonly STABILITY_THRESHOLD_MS = 2_000; // 2 seconds
+
+    constructor(conversationId: string) {
+        this.state = {
+            conversationId,
+            isThinking: false,
+            toolsInProgress: new Map(),
+            lastActivityTime: Date.now(),
+            status: 'idle',
+            messageCount: 0,
+            toolsCompleted: 0,
+        };
+    }
+
+    /**
+     * Mark when the model starts thinking
+     */
+    onModelThinkingStart(): void {
+        this.state.isThinking = true;
+        this.state.status = 'thinking';
+        this.state.lastActivityTime = Date.now();
+        log({ module: 'conversation-session', sessionId: this.state.conversationId }, 
+            `[会话 ${this.state.conversationId}] 模型开始思考`);
+    }
+
+    /**
+     * Mark when the model finishes thinking
+     */
+    onModelThinkingEnd(): void {
+        this.state.isThinking = false;
+        this.state.lastActivityTime = Date.now();
+        log({ module: 'conversation-session', sessionId: this.state.conversationId }, 
+            `[会话 ${this.state.conversationId}] 模型思考完成`);
+    }
+
+    /**
+     * Mark when a tool starts executing
+     */
+    onToolStart(toolId: string): void {
+        this.state.toolsInProgress.set(toolId, true);
+        this.state.status = 'executing_tool';
+        this.state.lastActivityTime = Date.now();
+        log({ module: 'conversation-session', sessionId: this.state.conversationId }, 
+            `[会话 ${this.state.conversationId}] 工具启动: ${toolId}`);
+    }
+
+    /**
+     * Mark when a tool finishes executing (or fails)
+     */
+    onToolEnd(toolId: string): void {
+        this.state.toolsInProgress.delete(toolId);
+        this.state.toolsCompleted++;
+        this.state.lastActivityTime = Date.now();
+        
+        if (this.state.toolsInProgress.size === 0 && !this.state.isThinking) {
+            this.state.status = 'completed';
+        }
+        
+        log({ module: 'conversation-session', sessionId: this.state.conversationId }, 
+            `[会话 ${this.state.conversationId}] 工具完成: ${toolId}, 剩余: ${this.state.toolsInProgress.size}`);
+    }
+
+    /**
+     * Mark when a new message is received/sent
+     */
+    onNewMessage(): void {
+        this.state.messageCount++;
+        this.state.lastActivityTime = Date.now();
+    }
+
+    /**
+     * Mark session as idle (no pending work)
+     */
+    onIdle(): void {
+        this.state.status = 'idle';
+        this.state.isThinking = false;
+        this.state.toolsInProgress.clear();
+        this.state.lastActivityTime = Date.now();
+    }
+
+    /**
+     * Get the current state of the conversation
+     */
+    getState(): ConversationState {
+        const timeSinceActivity = Date.now() - this.state.lastActivityTime;
+        const timeoutDetected = timeSinceActivity > this.TIMEOUT_THRESHOLD_MS;
+
+        return {
+            conversationId: this.state.conversationId,
+            status: this.state.status,
+            isThinking: this.state.isThinking,
+            toolsInProgress: Array.from(this.state.toolsInProgress.keys()),
+            lastActivityTime: this.state.lastActivityTime,
+            messageCount: this.state.messageCount,
+            toolsCompleted: this.state.toolsCompleted,
+            timeoutDetected,
+        };
+    }
+
+    /**
+     * Get stability threshold for notification timing
+     */
+    getStabilityThresholdMs(): number {
+        return this.STABILITY_THRESHOLD_MS;
+    }
+
+    /**
+     * Check if enough time has passed since last activity for stability
+     */
+    isTimeStable(): boolean {
+        const timeSinceLastActivity = Date.now() - this.state.lastActivityTime;
+        return timeSinceLastActivity > this.STABILITY_THRESHOLD_MS;
+    }
+
+    /**
+     * Get time since last activity in ms
+     */
+    getTimeSinceLastActivity(): number {
+        return Date.now() - this.state.lastActivityTime;
+    }
+}
+
+// Global registry of conversation sessions (in-memory)
+// In production, this could be backed by Redis or similar
+const conversationSessions = new Map<string, ConversationSession>();
+
+/**
+ * Get or create a conversation session
+ */
+export function getOrCreateSession(conversationId: string): ConversationSession {
+    let session = conversationSessions.get(conversationId);
+    if (!session) {
+        session = new ConversationSession(conversationId);
+        conversationSessions.set(conversationId, session);
+    }
+    return session;
+}
+
+/**
+ * Get an existing session (returns undefined if not found)
+ */
+export function getSession(conversationId: string): ConversationSession | undefined {
+    return conversationSessions.get(conversationId);
+}
+
+/**
+ * Remove a session (e.g., when session is deleted)
+ */
+export function removeSession(conversationId: string): void {
+    conversationSessions.delete(conversationId);
+}

--- a/packages/happy-server/sources/app/session/NotificationManager.ts
+++ b/packages/happy-server/sources/app/session/NotificationManager.ts
@@ -1,41 +1,30 @@
 import { log } from "@/utils/log";
 import { Expo, ExpoPushMessage } from "expo-server-sdk";
 import { db } from "@/storage/db";
-import { getSessionTurnState, type SessionTurnState } from "@/app/presence/sessionTurnRuntime";
 
-/**
- * NotificationReadyState interface for notification stability checks.
- */
-export interface NotificationReadyState {
+export type NotificationType = 'session_completed' | 'permission_request' | 'session_error' | 'rate_limit';
+
+interface NotifyOptions {
     conversationId: string;
-    isThinking: boolean;
-    toolsInProgress: string[];
-    lastActivityTime: number;
-    status: 'idle' | 'thinking' | 'executing_tool' | 'completed';
-    timeoutDetected: boolean;
+    type: NotificationType;
+    title: string;
+    body: string;
+    /** Extra key/value pairs merged into push data payload */
+    extra?: Record<string, unknown>;
 }
 
 /**
- * NotificationManager handles Expo push notification delivery with stability checks.
- * 
- * It ensures notifications are only sent when:
- * - The model is not thinking
- * - No tools are currently executing
- * - At least 2 seconds have passed since last activity (stability window)
- * - The conversation status indicates completion
- * - No timeout has been detected
- * 
- * This prevents push notifications from being sent during intermediate states
- * when the conversation might still be ongoing.
+ * NotificationManager handles server-side Expo push delivery.
+ *
+ * Triggered directly by server events — no client heartbeat dependency:
+ *   - session_completed  : turn ended, CLI set taskCompleted
+ *   - permission_request : CLI needs user approval for a tool
+ *   - session_error      : unrecoverable error during execution
+ *   - rate_limit         : API quota exhausted
  */
 export class NotificationManager {
     private static instance: NotificationManager;
-    private retryTimeouts = new Map<string, NodeJS.Timeout>();
     private expo: Expo;
-    
-    // Timeouts
-    private readonly STABILITY_THRESHOLD_MS = 2_000; // 2 seconds - must wait this long after last activity
-    private readonly TIMEOUT_THRESHOLD_MS = 30_000; // 30 seconds - considered stuck if no activity this long
 
     private constructor() {
         this.expo = new Expo();
@@ -49,103 +38,122 @@ export class NotificationManager {
     }
 
     /**
-     * Main entry point: check state and send notification if ready
+     * Notify that the current turn completed successfully.
+     * Called by sessionUpdateHandler when turnEnded is detected.
      */
-    async checkAndNotify(conversationId: string): Promise<void> {
-        const turnState = getSessionTurnState(conversationId);
-        const state = this.buildNotificationState(conversationId, turnState);
-        
-        const readyToNotify = this.isReadyForNotification(state);
-
-        if (!readyToNotify) {
-            log({ module: 'notification-manager', sessionId: conversationId }, 
-                `[⏰ 检查中] 会话 ${conversationId} 状态未就绪，将在 1s 后重试`, {
-                    status: state.status,
-                    isThinking: state.isThinking,
-                    toolsInProgress: state.toolsInProgress.length,
-                    timeSinceActivity: Date.now() - state.lastActivityTime,
-                });
-            this.scheduleRetry(conversationId, 1000);
-            return;
-        }
-
-        log({ module: 'notification-manager', sessionId: conversationId }, 
-            `[✅ 发送通知] 会话 ${conversationId} 已完整完成，状态: ${state.status}`, {
-                timeSinceActivity: Date.now() - state.lastActivityTime,
-            });
-        
-        await this.sendNotification(conversationId, state);
-    }
-
-    /**
-     * Build notification-ready state from session turn state
-     */
-    private buildNotificationState(conversationId: string, turnState: SessionTurnState): NotificationReadyState {
-        const timeSinceActivity = Date.now() - turnState.lastHeartbeatAt;
-        
-        // Determine conversation status
-        let status: 'idle' | 'thinking' | 'executing_tool' | 'completed';
-        if (turnState.thinking) {
-            status = 'thinking';
-        } else if (turnState.awaitingTurnStart) {
-            status = 'executing_tool';
-        } else if (turnState.dispatching) {
-            status = 'executing_tool';
-        } else {
-            status = 'completed';
-        }
-
-        return {
+    async notifyCompleted(conversationId: string): Promise<void> {
+        await this.notify({
             conversationId,
-            isThinking: turnState.thinking,
-            toolsInProgress: [], // Tool tracking would require integration with tool execution
-            lastActivityTime: turnState.lastHeartbeatAt,
-            status,
-            timeoutDetected: timeSinceActivity > this.TIMEOUT_THRESHOLD_MS,
-        };
+            type: 'session_completed',
+            title: '✅ 任务完成',
+            body: '你的会话已完成，点击查看结果',
+        });
     }
 
     /**
-     * Check if the conversation state is ready for notification
+     * Notify that a tool requires user approval.
+     * Called directly from CLI via the existing permission push path —
+     * this server-side variant is for future consolidation.
      */
-    private isReadyForNotification(state: NotificationReadyState): boolean {
-        const timeSinceActivity = Date.now() - state.lastActivityTime;
-        
-        const checks = {
-            notThinking: !state.isThinking,
-            noToolsInProgress: state.toolsInProgress.length === 0,
-            stableTimestamp: timeSinceActivity > this.STABILITY_THRESHOLD_MS,
-            hasCompleted: state.status === 'completed' || state.status === 'idle',
-            notTimedOut: !state.timeoutDetected,
-        };
-
-        log({ module: 'notification-manager', sessionId: state.conversationId }, 
-            `[📋 检查日志] 会话 ${state.conversationId} 状态检查:`, checks);
-
-        return Object.values(checks).every(check => check);
+    async notifyPermissionRequest(conversationId: string, toolName: string): Promise<void> {
+        await this.notify({
+            conversationId,
+            type: 'permission_request',
+            title: '🔐 需要授权',
+            body: `Claude 想执行 ${toolName}，点击确认或拒绝`,
+            extra: { tool: toolName },
+        });
     }
 
     /**
-     * Schedule a retry check after a delay
+     * Notify that an unrecoverable error occurred.
+     * Called when CLI signals a fatal error via agentState or session event.
      */
-    private scheduleRetry(conversationId: string, delayMs: number): void {
-        // Cancel any existing retry for this conversation
-        const existingTimeout = this.retryTimeouts.get(conversationId);
-        if (existingTimeout) {
-            clearTimeout(existingTimeout);
+    async notifyError(conversationId: string, errorMessage: string): Promise<void> {
+        await this.notify({
+            conversationId,
+            type: 'session_error',
+            title: '❌ 执行出错',
+            body: errorMessage.length > 80 ? errorMessage.slice(0, 80) + '…' : errorMessage,
+            extra: { errorMessage },
+        });
+    }
+
+    /**
+     * Notify that the API rate limit has been exhausted.
+     */
+    async notifyRateLimit(conversationId: string): Promise<void> {
+        await this.notify({
+            conversationId,
+            type: 'rate_limit',
+            title: '⚠️ 限额用完',
+            body: 'API 限额已用完，点击查看详情',
+        });
+    }
+
+    /**
+     * Core send path: resolve owner → fetch tokens → push via Expo.
+     */
+    private async notify(opts: NotifyOptions): Promise<void> {
+        const { conversationId, type, title, body, extra } = opts;
+
+        try {
+            const ownerId = await this.getSessionOwnerId(conversationId);
+            if (!ownerId) {
+                log({ module: 'notification-manager', sessionId: conversationId },
+                    `[⚠️ 跳过] 会话不存在或无 owner (type=${type})`);
+                return;
+            }
+
+            const pushTokenRows = await db.accountPushToken.findMany({
+                where: { accountId: ownerId },
+                select: { token: true },
+            });
+
+            if (pushTokenRows.length === 0) {
+                log({ module: 'notification-manager', sessionId: conversationId },
+                    `[⚠️ 跳过] 用户无推送 token (type=${type})`);
+                return;
+            }
+
+            const badgeCount = await this.incrementBadgeCount(ownerId);
+
+            const data: Record<string, unknown> = {
+                type,
+                sessionId: conversationId,
+                timestamp: Date.now(),
+                ...extra,
+            };
+
+            const messages: ExpoPushMessage[] = pushTokenRows
+                .filter(row => Expo.isExpoPushToken(row.token))
+                .map(row => ({
+                    to: row.token,
+                    title,
+                    body,
+                    data,
+                    sound: 'default' as const,
+                    priority: 'high' as const,
+                    badge: badgeCount,
+                    channelId: 'default',
+                }));
+
+            if (messages.length === 0) {
+                log({ module: 'notification-manager', sessionId: conversationId },
+                    `[⚠️ 跳过] 无有效 Expo token (type=${type})`);
+                return;
+            }
+
+            await this.sendChunked(messages, conversationId, type);
+
+            log({ module: 'notification-manager', sessionId: conversationId },
+                `[✅ 已推送] type=${type}, devices=${messages.length}`);
+        } catch (error) {
+            log({ module: 'notification-manager', level: 'error', sessionId: conversationId },
+                `[❌ 推送失败] type=${type}: ${error}`);
         }
-
-        const timeout = setTimeout(async () => {
-            this.retryTimeouts.delete(conversationId);
-            await this.checkAndNotify(conversationId);
-        }, delayMs);
-
-        this.retryTimeouts.set(conversationId, timeout);
     }
 
-    /**
-     * Get session owner ID from conversation ID
-     */
     private async getSessionOwnerId(conversationId: string): Promise<string | null> {
         const session = await db.session.findUnique({
             where: { id: conversationId },
@@ -154,139 +162,34 @@ export class NotificationManager {
         return session?.accountId ?? null;
     }
 
-    /**
-     * Send push notification via Expo Push API
-     */
-    private async sendPushViaExpo(tokens: string[], title: string, body: string, data: Record<string, unknown>): Promise<void> {
-        // Filter out invalid tokens
-        const validMessages: ExpoPushMessage[] = tokens
-            .filter(token => Expo.isExpoPushToken(token))
-            .map(token => ({
-                to: token,
-                title,
-                body,
-                data,
-                sound: 'default' as const,
-                priority: 'high' as const,
-            }));
+    private async incrementBadgeCount(ownerId: string): Promise<number> {
+        const updated = await db.account.update({
+            where: { id: ownerId },
+            data: { badgeCount: { increment: 1 } },
+            select: { badgeCount: true },
+        });
+        return updated.badgeCount;
+    }
 
-        if (validMessages.length === 0) {
-            log({ module: 'notification-manager' }, `[⚠️ 跳过] 没有有效的 Expo Push Token`);
-            return;
-        }
-
-        // Chunk and send with retry
-        const chunks = this.expo.chunkPushNotifications(validMessages);
-        
+    private async sendChunked(messages: ExpoPushMessage[], conversationId: string, type: NotificationType): Promise<void> {
+        const chunks = this.expo.chunkPushNotifications(messages);
         for (const chunk of chunks) {
             try {
-                const ticketChunk = await this.expo.sendPushNotificationsAsync(chunk);
-                
-                // Log any errors
-                const errors = ticketChunk.filter(ticket => ticket.status === 'error');
+                const tickets = await this.expo.sendPushNotificationsAsync(chunk);
+                const errors = tickets.filter(t => t.status === 'error');
                 if (errors.length > 0) {
-                    log({ module: 'notification-manager' }, 
-                        `[⚠️ 部分推送失败] ${errors.length}/${ticketChunk.length}`, 
-                        errors.map(e => e.message)
-                    );
+                    log({ module: 'notification-manager', sessionId: conversationId },
+                        `[⚠️ 部分失败] type=${type}, failed=${errors.length}/${tickets.length}`,
+                        errors.map(e => e.message));
                 }
             } catch (error) {
-                log({ module: 'notification-manager', level: 'error' }, 
-                    `[❌ 推送发送失败] chunk error: ${error}`);
+                log({ module: 'notification-manager', level: 'error', sessionId: conversationId },
+                    `[❌ chunk 发送失败] type=${type}: ${error}`);
             }
         }
-    }
-
-    /**
-     * Actually send the push notification
-     */
-    private async sendNotification(
-        conversationId: string, 
-        state: NotificationReadyState
-    ): Promise<void> {
-        log({ module: 'notification-manager', sessionId: conversationId }, 
-            `[🚀 准备发送推送] 会话 ${conversationId}:`, {
-                finalStatus: state.status,
-                isThinking: state.isThinking,
-                timestamp: new Date().toISOString(),
-            });
-
-        try {
-            // Get session owner
-            const ownerId = await this.getSessionOwnerId(conversationId);
-            if (!ownerId) {
-                log({ module: 'notification-manager', sessionId: conversationId }, 
-                    `[⚠️ 跳过] 会话不存在或无 owner`);
-                return;
-            }
-
-            // Fetch user's push tokens
-            const pushTokens = await db.accountPushToken.findMany({
-                where: { accountId: ownerId },
-                select: { token: true },
-            });
-
-            if (pushTokens.length === 0) {
-                log({ module: 'notification-manager', sessionId: conversationId }, 
-                    `[⚠️ 跳过] 用户没有注册推送 token`);
-                return;
-            }
-
-            const tokens = pushTokens.map(pt => pt.token);
-
-            // Prepare notification content
-            const title = '💬 新消息';
-            const body = '你的对话有新消息';
-            const data = {
-                type: 'session_message',
-                sessionId: conversationId,
-                timestamp: Date.now(),
-            };
-
-            // Send push via Expo
-            await this.sendPushViaExpo(tokens, title, body, data);
-
-            // Increment badge count
-            await db.account.update({
-                where: { id: ownerId },
-                data: { badgeCount: { increment: 1 } },
-            });
-
-            log({ module: 'notification-manager', sessionId: conversationId }, 
-                `[✅ 推送已发送] 已发送到 ${tokens.length} 个设备`, {
-                    finalStatus: state.status,
-                    timestamp: new Date().toISOString(),
-                });
-
-        } catch (error) {
-            log({ module: 'notification-manager', level: 'error', sessionId: conversationId }, 
-                `[❌ 发送推送失败] ${error}`);
-        }
-    }
-
-    /**
-     * Cancel any pending retry for a conversation
-     */
-    cancelRetry(conversationId: string): void {
-        const existingTimeout = this.retryTimeouts.get(conversationId);
-        if (existingTimeout) {
-            clearTimeout(existingTimeout);
-            this.retryTimeouts.delete(conversationId);
-        }
-    }
-
-    /**
-     * Cleanup all pending retries (for shutdown)
-     */
-    shutdown(): void {
-        for (const [conversationId, timeout] of this.retryTimeouts) {
-            clearTimeout(timeout);
-        }
-        this.retryTimeouts.clear();
     }
 }
 
-// Convenience function for getting the singleton instance
 export function getNotificationManager(): NotificationManager {
     return NotificationManager.getInstance();
 }

--- a/packages/happy-server/sources/app/session/NotificationManager.ts
+++ b/packages/happy-server/sources/app/session/NotificationManager.ts
@@ -1,0 +1,214 @@
+import { log } from "@/utils/log";
+import { db } from "@/storage/db";
+import { eventRouter, buildNewMessageUpdate } from "@/app/events/eventRouter";
+import { randomKeyNaked } from "@/utils/randomKeyNaked";
+import { getSessionTurnState, type SessionTurnState } from "@/app/presence/sessionTurnRuntime";
+
+/**
+ * Conversation state interface for notification stability checks.
+ * Derived from SessionTurnState but includes additional fields.
+ */
+export interface NotificationReadyState {
+    conversationId: string;
+    isThinking: boolean;
+    toolsInProgress: string[];
+    lastActivityTime: number;
+    status: 'idle' | 'thinking' | 'executing_tool' | 'completed';
+    timeoutDetected: boolean;
+}
+
+/**
+ * NotificationManager handles push notification delivery with stability checks.
+ * 
+ * It ensures notifications are only sent when:
+ * - The model is not thinking
+ * - No tools are currently executing
+ * - At least 2 seconds have passed since last activity (stability window)
+ * - The conversation status indicates completion
+ * - No timeout has been detected
+ * 
+ * This prevents push notifications from being sent during intermediate states
+ * when the conversation might still be ongoing.
+ */
+export class NotificationManager {
+    private static instance: NotificationManager;
+    private retryTimeouts = new Map<string, NodeJS.Timeout>();
+    
+    // Timeouts
+    private readonly STABILITY_THRESHOLD_MS = 2_000; // 2 seconds - must wait this long after last activity
+    private readonly TIMEOUT_THRESHOLD_MS = 30_000; // 30 seconds - considered stuck if no activity this long
+
+    private constructor() {}
+
+    static getInstance(): NotificationManager {
+        if (!NotificationManager.instance) {
+            NotificationManager.instance = new NotificationManager();
+        }
+        return NotificationManager.instance;
+    }
+
+    /**
+     * Main entry point: check state and send notification if ready
+     */
+    async checkAndNotify(conversationId: string): Promise<void> {
+        const turnState = getSessionTurnState(conversationId);
+        const state = this.buildNotificationState(conversationId, turnState);
+        
+        const readyToNotify = this.isReadyForNotification(state);
+
+        if (!readyToNotify) {
+            log({ module: 'notification-manager', sessionId: conversationId }, 
+                `[⏰ 检查中] 会话 ${conversationId} 状态未就绪，将在 1s 后重试`, {
+                    status: state.status,
+                    isThinking: state.isThinking,
+                    toolsInProgress: state.toolsInProgress.length,
+                    timeSinceActivity: Date.now() - state.lastActivityTime,
+                });
+            this.scheduleRetry(conversationId, 1000);
+            return;
+        }
+
+        log({ module: 'notification-manager', sessionId: conversationId }, 
+            `[✅ 发送通知] 会话 ${conversationId} 已完整完成，状态: ${state.status}`, {
+                timeSinceActivity: Date.now() - state.lastActivityTime,
+            });
+        
+        await this.sendNotification(conversationId, state);
+    }
+
+    /**
+     * Build notification-ready state from session turn state
+     */
+    private buildNotificationState(conversationId: string, turnState: SessionTurnState): NotificationReadyState {
+        const timeSinceActivity = Date.now() - turnState.lastHeartbeatAt;
+        
+        // Determine conversation status
+        let status: 'idle' | 'thinking' | 'executing_tool' | 'completed';
+        if (turnState.thinking) {
+            status = 'thinking';
+        } else if (turnState.awaitingTurnStart) {
+            status = 'executing_tool';
+        } else if (turnState.dispatching) {
+            status = 'executing_tool';
+        } else {
+            status = 'completed';
+        }
+
+        return {
+            conversationId,
+            isThinking: turnState.thinking,
+            toolsInProgress: [], // Tool tracking would require integration with tool execution
+            lastActivityTime: turnState.lastHeartbeatAt,
+            status,
+            timeoutDetected: timeSinceActivity > this.TIMEOUT_THRESHOLD_MS,
+        };
+    }
+
+    /**
+     * Check if the conversation state is ready for notification
+     */
+    private isReadyForNotification(state: NotificationReadyState): boolean {
+        const timeSinceActivity = Date.now() - state.lastActivityTime;
+        
+        const checks = {
+            notThinking: !state.isThinking,
+            noToolsInProgress: state.toolsInProgress.length === 0,
+            stableTimestamp: timeSinceActivity > this.STABILITY_THRESHOLD_MS,
+            hasCompleted: state.status === 'completed' || state.status === 'idle',
+            notTimedOut: !state.timeoutDetected,
+        };
+
+        log({ module: 'notification-manager', sessionId: state.conversationId }, 
+            `[📋 检查日志] 会话 ${state.conversationId} 状态检查:`, checks);
+
+        return Object.values(checks).every(check => check);
+    }
+
+    /**
+     * Schedule a retry check after a delay
+     */
+    private scheduleRetry(conversationId: string, delayMs: number): void {
+        // Cancel any existing retry for this conversation
+        const existingTimeout = this.retryTimeouts.get(conversationId);
+        if (existingTimeout) {
+            clearTimeout(existingTimeout);
+        }
+
+        const timeout = setTimeout(async () => {
+            this.retryTimeouts.delete(conversationId);
+            await this.checkAndNotify(conversationId);
+        }, delayMs);
+
+        this.retryTimeouts.set(conversationId, timeout);
+    }
+
+    /**
+     * Actually send the push notification
+     * 
+     * In a real implementation, this would:
+     * 1. Fetch user's push tokens from db.accountPushToken
+     * 2. Send via FCM/APNs/Expo push service
+     * 3. Handle delivery failures with retries
+     */
+    private async sendNotification(
+        conversationId: string, 
+        state: NotificationReadyState
+    ): Promise<void> {
+        log({ module: 'notification-manager', sessionId: conversationId }, 
+            `[🚀 通知已发送] 会话 ${conversationId}:`, {
+                finalStatus: state.status,
+                isThinking: state.isThinking,
+                timestamp: new Date().toISOString(),
+            });
+
+        // TODO: Actual push notification implementation
+        // This would typically:
+        // 1. Get user's push tokens: await db.accountPushToken.findMany({ where: { accountId } })
+        // 2. Send push via FCM/APNs/Expo
+        // 3. Update badge count
+        // 4. Log delivery status
+
+        /*
+        Example implementation:
+        
+        const pushTokens = await db.accountPushToken.findMany({
+            where: { accountId: ownerId }
+        });
+        
+        for (const token of pushTokens) {
+            await sendPushNotification({
+                token: token.token,
+                title: 'New Message',
+                body: 'You have a new message in your conversation',
+                data: { sessionId: conversationId }
+            });
+        }
+        */
+    }
+
+    /**
+     * Cancel any pending retry for a conversation
+     */
+    cancelRetry(conversationId: string): void {
+        const existingTimeout = this.retryTimeouts.get(conversationId);
+        if (existingTimeout) {
+            clearTimeout(existingTimeout);
+            this.retryTimeouts.delete(conversationId);
+        }
+    }
+
+    /**
+     * Cleanup all pending retries (for shutdown)
+     */
+    shutdown(): void {
+        for (const [conversationId, timeout] of this.retryTimeouts) {
+            clearTimeout(timeout);
+        }
+        this.retryTimeouts.clear();
+    }
+}
+
+// Convenience function for getting the singleton instance
+export function getNotificationManager(): NotificationManager {
+    return NotificationManager.getInstance();
+}

--- a/packages/happy-server/sources/app/session/NotificationManager.ts
+++ b/packages/happy-server/sources/app/session/NotificationManager.ts
@@ -1,12 +1,10 @@
 import { log } from "@/utils/log";
+import { Expo, ExpoPushMessage } from "expo-server-sdk";
 import { db } from "@/storage/db";
-import { eventRouter, buildNewMessageUpdate } from "@/app/events/eventRouter";
-import { randomKeyNaked } from "@/utils/randomKeyNaked";
 import { getSessionTurnState, type SessionTurnState } from "@/app/presence/sessionTurnRuntime";
 
 /**
- * Conversation state interface for notification stability checks.
- * Derived from SessionTurnState but includes additional fields.
+ * NotificationReadyState interface for notification stability checks.
  */
 export interface NotificationReadyState {
     conversationId: string;
@@ -18,7 +16,7 @@ export interface NotificationReadyState {
 }
 
 /**
- * NotificationManager handles push notification delivery with stability checks.
+ * NotificationManager handles Expo push notification delivery with stability checks.
  * 
  * It ensures notifications are only sent when:
  * - The model is not thinking
@@ -33,12 +31,15 @@ export interface NotificationReadyState {
 export class NotificationManager {
     private static instance: NotificationManager;
     private retryTimeouts = new Map<string, NodeJS.Timeout>();
+    private expo: Expo;
     
     // Timeouts
     private readonly STABILITY_THRESHOLD_MS = 2_000; // 2 seconds - must wait this long after last activity
     private readonly TIMEOUT_THRESHOLD_MS = 30_000; // 30 seconds - considered stuck if no activity this long
 
-    private constructor() {}
+    private constructor() {
+        this.expo = new Expo();
+    }
 
     static getInstance(): NotificationManager {
         if (!NotificationManager.instance) {
@@ -143,47 +144,124 @@ export class NotificationManager {
     }
 
     /**
+     * Get session owner ID from conversation ID
+     */
+    private async getSessionOwnerId(conversationId: string): Promise<string | null> {
+        const session = await db.session.findUnique({
+            where: { id: conversationId },
+            select: { accountId: true },
+        });
+        return session?.accountId ?? null;
+    }
+
+    /**
+     * Send push notification via Expo Push API
+     */
+    private async sendPushViaExpo(tokens: string[], title: string, body: string, data: Record<string, unknown>): Promise<void> {
+        // Filter out invalid tokens
+        const validMessages: ExpoPushMessage[] = tokens
+            .filter(token => Expo.isExpoPushToken(token))
+            .map(token => ({
+                to: token,
+                title,
+                body,
+                data,
+                sound: 'default' as const,
+                priority: 'high' as const,
+            }));
+
+        if (validMessages.length === 0) {
+            log({ module: 'notification-manager' }, `[⚠️ 跳过] 没有有效的 Expo Push Token`);
+            return;
+        }
+
+        // Chunk and send with retry
+        const chunks = this.expo.chunkPushNotifications(validMessages);
+        
+        for (const chunk of chunks) {
+            try {
+                const ticketChunk = await this.expo.sendPushNotificationsAsync(chunk);
+                
+                // Log any errors
+                const errors = ticketChunk.filter(ticket => ticket.status === 'error');
+                if (errors.length > 0) {
+                    log({ module: 'notification-manager' }, 
+                        `[⚠️ 部分推送失败] ${errors.length}/${ticketChunk.length}`, 
+                        errors.map(e => e.message)
+                    );
+                }
+            } catch (error) {
+                log({ module: 'notification-manager', level: 'error' }, 
+                    `[❌ 推送发送失败] chunk error: ${error}`);
+            }
+        }
+    }
+
+    /**
      * Actually send the push notification
-     * 
-     * In a real implementation, this would:
-     * 1. Fetch user's push tokens from db.accountPushToken
-     * 2. Send via FCM/APNs/Expo push service
-     * 3. Handle delivery failures with retries
      */
     private async sendNotification(
         conversationId: string, 
         state: NotificationReadyState
     ): Promise<void> {
         log({ module: 'notification-manager', sessionId: conversationId }, 
-            `[🚀 通知已发送] 会话 ${conversationId}:`, {
+            `[🚀 准备发送推送] 会话 ${conversationId}:`, {
                 finalStatus: state.status,
                 isThinking: state.isThinking,
                 timestamp: new Date().toISOString(),
             });
 
-        // TODO: Actual push notification implementation
-        // This would typically:
-        // 1. Get user's push tokens: await db.accountPushToken.findMany({ where: { accountId } })
-        // 2. Send push via FCM/APNs/Expo
-        // 3. Update badge count
-        // 4. Log delivery status
+        try {
+            // Get session owner
+            const ownerId = await this.getSessionOwnerId(conversationId);
+            if (!ownerId) {
+                log({ module: 'notification-manager', sessionId: conversationId }, 
+                    `[⚠️ 跳过] 会话不存在或无 owner`);
+                return;
+            }
 
-        /*
-        Example implementation:
-        
-        const pushTokens = await db.accountPushToken.findMany({
-            where: { accountId: ownerId }
-        });
-        
-        for (const token of pushTokens) {
-            await sendPushNotification({
-                token: token.token,
-                title: 'New Message',
-                body: 'You have a new message in your conversation',
-                data: { sessionId: conversationId }
+            // Fetch user's push tokens
+            const pushTokens = await db.accountPushToken.findMany({
+                where: { accountId: ownerId },
+                select: { token: true },
             });
+
+            if (pushTokens.length === 0) {
+                log({ module: 'notification-manager', sessionId: conversationId }, 
+                    `[⚠️ 跳过] 用户没有注册推送 token`);
+                return;
+            }
+
+            const tokens = pushTokens.map(pt => pt.token);
+
+            // Prepare notification content
+            const title = '💬 新消息';
+            const body = '你的对话有新消息';
+            const data = {
+                type: 'session_message',
+                sessionId: conversationId,
+                timestamp: Date.now(),
+            };
+
+            // Send push via Expo
+            await this.sendPushViaExpo(tokens, title, body, data);
+
+            // Increment badge count
+            await db.account.update({
+                where: { id: ownerId },
+                data: { badgeCount: { increment: 1 } },
+            });
+
+            log({ module: 'notification-manager', sessionId: conversationId }, 
+                `[✅ 推送已发送] 已发送到 ${tokens.length} 个设备`, {
+                    finalStatus: state.status,
+                    timestamp: new Date().toISOString(),
+                });
+
+        } catch (error) {
+            log({ module: 'notification-manager', level: 'error', sessionId: conversationId }, 
+                `[❌ 发送推送失败] ${error}`);
         }
-        */
     }
 
     /**


### PR DESCRIPTION
This PR builds on PR #1 and fixes the remaining notification issues.

## Bugs Fixed

- lastHeartbeatAt initialized to 0 caused immediate timeout detection, blocking all completion notifications
- Missing channelId 'default' caused Android 8.0+ to silently drop all FCM messages

## New: Error and Rate Limit Notifications

Added session-notify socket event so CLI can report errors and rate limits. Server routes to NotificationManager.notifyError() / notifyRateLimit().

CLI side: claudeRemoteLauncher, runCodex, runGemini now emit session-notify on error/rate-limit.

## Architecture: NotificationManager rewritten to direct method calls (Method A)

Before: polling/heartbeat model (notificationMgr.checkAndNotify)
After: direct calls (notifyCompleted / notifyPermissionRequest / notifyError / notifyRateLimit)

🤖 Generated with Claude Code (https://claude.com/claude-code)