### PR TITLE
fix(github): resolve Android OAuth "invalid state" error on repeated auth attempts

### DIFF
--- a/packages/happy-app/sources/app/(app)/github-callback.tsx
+++ b/packages/happy-app/sources/app/(app)/github-callback.tsx
@@ -1,0 +1,20 @@
+// On Android, openAuthSessionAsync does not fully intercept the redirect URL
+// at the OS level (unlike iOS's ASWebAuthenticationSession). The deep link is
+// delivered to both the auth session handler AND Expo Router simultaneously.
+//
+// By placing this file inside the (app) group, it shares the same Stack
+// navigator as the Settings page. When Expo Router pushes this screen on top
+// of [Home, Settings], router.back() correctly pops back to Settings.
+//
+// On iOS this route is never reached.
+
+import { useRouter } from 'expo-router';
+import { useEffect } from 'react';
+
+export default function GitHubCallback() {
+    const router = useRouter();
+    useEffect(() => {
+        router.back();
+    }, []);
+    return null;
+}

--- a/packages/happy-app/sources/components/SettingsView.tsx
+++ b/packages/happy-app/sources/components/SettingsView.tsx
@@ -1,4 +1,4 @@
-import { View, ScrollView, Pressable, Platform, Linking } from 'react-native';
+import { View, ScrollView, Pressable, Platform, Linking, AppState } from 'react-native';
 import * as WebBrowser from 'expo-web-browser';
 import { Image } from 'expo-image';
 import * as React from 'react';
@@ -76,17 +76,64 @@ export const SettingsView = React.memo(function SettingsView() {
 
     // Connection status
     const isGitHubConnected = !!profile.github;
+
     // GitHub connection
-    const [connectingGitHub, connectGitHub] = useHappyAction(async () => {
+    const [connectingGitHub, connectGitHub, cancelConnectGitHub] = useHappyAction(async () => {
         if (Platform.OS === 'web') {
             const params = await getGitHubOAuthParams(auth.credentials!);
             await Linking.openURL(params.url);
         } else {
             const callbackUrl = 'happy://github-callback';
             const params = await getGitHubOAuthParams(auth.credentials!, callbackUrl);
-            await WebBrowser.openAuthSessionAsync(params.url, callbackUrl);
+
+            if (Platform.OS === 'android') {
+                // Android's openAuthSessionAsync uses a JS polyfill that tracks auth
+                // state in a module-level _redirectSubscription variable. If the
+                // redirect races with Expo Router's deep-link handling, this variable
+                // can be left dangling, causing "invalid state" errors on subsequent
+                // calls. Neither dismissAuthSession() nor coolDownAsync() clear it.
+                //
+                // Bypass the polyfill entirely: open Chrome Custom Tab via the
+                // stateless openBrowserAsync, then listen for the redirect ourselves.
+                const subs: Array<{ remove(): void }> = [];
+                try {
+                    const done = new Promise<void>((resolve) => {
+                        let settled = false;
+
+                        subs.push(Linking.addEventListener('url', (event: { url: string }) => {
+                            if (!settled && event.url.startsWith(callbackUrl)) {
+                                settled = true;
+                                resolve();
+                            }
+                        }));
+
+                        // Detect when user returns without completing auth (pressed back).
+                        // Give a brief grace period for the redirect deep-link to arrive.
+                        subs.push(AppState.addEventListener('change', (state) => {
+                            if (state === 'active' && !settled) {
+                                setTimeout(() => {
+                                    if (!settled) {
+                                        settled = true;
+                                        resolve();
+                                    }
+                                }, 2000);
+                            }
+                        }));
+                    });
+
+                    await WebBrowser.openBrowserAsync(params.url);
+                    await done;
+                } finally {
+                    subs.forEach((s) => s.remove());
+                }
+            } else {
+                const result = await WebBrowser.openAuthSessionAsync(params.url, callbackUrl);
+                if (result.type === WebBrowser.WebBrowserResultType.CANCEL || result.type === WebBrowser.WebBrowserResultType.DISMISS) {
+                    return;
+                }
+            }
         }
-    });
+    }, { timeoutMs: 35_000 });
 
     // GitHub disconnection
     const [disconnectingGitHub, handleDisconnectGitHub] = useHappyAction(async () => {

--- a/packages/happy-app/sources/hooks/useHappyAction.ts
+++ b/packages/happy-app/sources/hooks/useHappyAction.ts
@@ -2,15 +2,38 @@ import * as React from 'react';
 import { Modal } from '@/modal';
 import { HappyError } from '@/utils/errors';
 
-export function useHappyAction(action: () => Promise<void>) {
+export function useHappyAction(action: () => Promise<void>, opts?: { timeoutMs?: number }) {
     const [loading, setLoading] = React.useState(false);
     const loadingRef = React.useRef(false);
+    const timeoutRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
+    const abortRef = React.useRef(false);
+    // Default 60s timeout
+    const timeoutMs = opts?.timeoutMs ?? 60_000;
+
+    const cancel = React.useCallback(() => {
+        abortRef.current = true;
+        if (timeoutRef.current) {
+            clearTimeout(timeoutRef.current);
+            timeoutRef.current = null;
+        }
+        loadingRef.current = false;
+        setLoading(false);
+    }, []);
+
     const doAction = React.useCallback(() => {
         if (loadingRef.current) {
             return;
         }
         loadingRef.current = true;
+        abortRef.current = false;
         setLoading(true);
+
+        timeoutRef.current = setTimeout(() => {
+            abortRef.current = true;
+            loadingRef.current = false;
+            setLoading(false);
+        }, timeoutMs);
+
         (async () => {
             try {
                 while (true) {
@@ -18,6 +41,7 @@ export function useHappyAction(action: () => Promise<void>) {
                         await action();
                         break;
                     } catch (e) {
+                        if (abortRef.current) break;
                         if (e instanceof HappyError) {
                             // if (e.canTryAgain) {
                             //     Modal.alert('Error', e.message, [{ text: 'Try again' }, { text: 'Cancel', style: 'cancel' }]) 
@@ -30,16 +54,35 @@ export function useHappyAction(action: () => Promise<void>) {
                             Modal.alert('Error', e.message, [{ text: 'OK', style: 'cancel' }]);
                             break;
                         } else {
-                            Modal.alert('Error', 'Unknown error', [{ text: 'OK', style: 'cancel' }]);
+                            const message = e instanceof Error ? e.message : 'Unknown error';
+                            Modal.alert('Error', message, [{ text: 'OK', style: 'cancel' }]);
                             break;
                         }
                     }
                 }
             } finally {
+                if (timeoutRef.current) {
+                    clearTimeout(timeoutRef.current);
+                    timeoutRef.current = null;
+                }
                 loadingRef.current = false;
                 setLoading(false);
             }
         })();
-    }, [action]);
-    return [loading, doAction] as const;
+    }, [action, timeoutMs]);
+
+    // Cleanup on unmount
+    React.useEffect(() => {
+        return () => {
+            abortRef.current = true;
+            if (timeoutRef.current) {
+                clearTimeout(timeoutRef.current);
+                timeoutRef.current = null;
+            }
+            loadingRef.current = false;
+            setLoading(false);
+        };
+    }, []);
+
+    return [loading, doAction, cancel] as const;
 }

--- a/packages/happy-server/sources/app/api/routes/connectRoutes.ts
+++ b/packages/happy-server/sources/app/api/routes/connectRoutes.ts
@@ -100,22 +100,22 @@ export function connectRoutes(app: Fastify) {
         const appUrl = process.env.APP_URL || 'https://app.happy-next.com';
 
         // Verify the state token to get userId
-        const tokenData = await auth.verifyGithubToken(state);
-        if (!tokenData) {
-            log({ module: 'github-oauth' }, `Invalid state token: ${state}`);
-            return reply.redirect(`${appUrl}?error=invalid_state`);
-        }
-
-        const userId = tokenData.userId;
-        const baseUrl = tokenData.callback || appUrl;
-        const clientId = process.env.GITHUB_CLIENT_ID;
-        const clientSecret = process.env.GITHUB_CLIENT_SECRET;
-
-        if (!clientId || !clientSecret) {
-            return reply.redirect(`${baseUrl}?error=server_config`);
-        }
-
         try {
+            const tokenData = await auth.verifyGithubToken(state);
+            if (!tokenData) {
+                log({ module: 'github-oauth' }, `Invalid state token: ${state}`);
+                return reply.redirect(`${appUrl}?error=invalid_state`);
+            }
+
+            const userId = tokenData.userId;
+            const baseUrl = tokenData.callback || appUrl;
+            const clientId = process.env.GITHUB_CLIENT_ID;
+            const clientSecret = process.env.GITHUB_CLIENT_SECRET;
+
+            if (!clientId || !clientSecret) {
+                return reply.redirect(`${baseUrl}?error=server_config`);
+            }
+
             // Exchange code for access token
             const tokenResponse = await fetch('https://github.com/login/oauth/access_token', {
                 method: 'POST',
@@ -165,7 +165,7 @@ export function connectRoutes(app: Fastify) {
 
         } catch (error) {
             log({ module: 'github-oauth' }, `Error in GitHub GET callback: ${error}`);
-            return reply.redirect(`${baseUrl}?error=server_error`);
+            return reply.redirect(`${appUrl}?error=server_error`);
         }
     });
 


### PR DESCRIPTION
## Summary

修复 Android 上 GitHub OAuth 在重复授权时出现 "invalid state" 错误的问题。

Android 的 `expo-web-browser` 的 `openAuthSessionAsync` 使用了一个 JS polyfill，它会在模块级别的 `_redirectSubscription` 变量中跟踪授权状态。当重定向与 Expo Router 的深度链接处理发生竞争时，这个变量可能被悬空，导致后续调用出现 "invalid state" 错误。`dismissAuthSession()` 和 `coolDownAsync()` 都无法清除它。

## Changes

- **新增** `github-callback.tsx` 路由
  - Android 的 `openAuthSessionAsync` 无法在 OS 层面完全拦截重定向 URL（不像 iOS 的 `ASWebAuthenticationSession`）
  - 深度链接会同时传递给授权会话处理器和 Expo Router
  - 将此文件放在 `(app)` 组内，使其与 Settings 页面共享同一个 Stack navigator
  - 当 Expo Router 将此页面推送到 `[Home, Settings]` 之上时，`router.back()` 能正确返回到 Settings
  - 在 iOS 上此路由永远不会被访问

- **修改** `SettingsView.tsx` - 在 Android 上绕过有问题的 polyfill，改用无状态的 `openBrowserAsync` + 手动 `Linking/AppState` 监听器

- **增强** `useHappyAction.ts` - 添加 timeout/cancel 支持，支持 35 秒超时处理 OAuth 流程

- **修复** `connectRoutes.ts` - 用 try-catch 包装服务器端 OAuth 回调，增强错误处理；修复错误重定向 URL 使用 `baseUrl` 而非 `appUrl` 的问题

## Testing

- [x] Tested locally
- [ ] Existing tests pass
- [ ] New tests added (if applicable)

## Related issues

Closes #