### PR TITLE
fix(server): fix shutdown handler race condition causing Prisma errors on exit

### DIFF
--- a/packages/happy-server/sources/app/messageDelivery/timeout.ts
+++ b/packages/happy-server/sources/app/messageDelivery/timeout.ts
@@ -74,9 +74,7 @@ export async function markTimedOutDeliveryIssues(nowMs: number = Date.now()) {
 
 export function startMessageDeliveryTimeoutWorker() {
     forever('message-delivery-timeout', async () => {
-        while (true) {
-            await markTimedOutDeliveryIssues();
-            await delay(MESSAGE_DELIVERY_SCAN_INTERVAL_MS, shutdownSignal);
-        }
+        await markTimedOutDeliveryIssues();
+        await delay(MESSAGE_DELIVERY_SCAN_INTERVAL_MS, shutdownSignal);
     });
 }

--- a/packages/happy-server/sources/app/orchestrator/scheduler.ts
+++ b/packages/happy-server/sources/app/orchestrator/scheduler.ts
@@ -754,15 +754,13 @@ export async function orchestratorSchedulerTick(now: Date = new Date()): Promise
 
 export function startOrchestratorScheduler() {
     forever('orchestrator-scheduler', async () => {
-        while (true) {
-            try {
-                await orchestratorSchedulerTick();
-            } catch (error) {
-                const message = error instanceof Error ? error.message : String(error);
-                warn({ module: 'orchestrator-scheduler' }, `schedulerTick failed: ${message}`);
-            }
-            await delay(ORCHESTRATOR_SCHEDULER_INTERVAL_MS, shutdownSignal);
+        try {
+            await orchestratorSchedulerTick();
+        } catch (error) {
+            const message = error instanceof Error ? error.message : String(error);
+            warn({ module: 'orchestrator-scheduler' }, `schedulerTick failed: ${message}`);
         }
+        await delay(ORCHESTRATOR_SCHEDULER_INTERVAL_MS, shutdownSignal);
     });
     log({ module: 'orchestrator-scheduler' }, 'Orchestrator scheduler started');
 }

--- a/packages/happy-server/sources/app/presence/timeout.ts
+++ b/packages/happy-server/sources/app/presence/timeout.ts
@@ -6,57 +6,54 @@ import { buildMachineActivityEphemeral, buildSessionActivityEphemeral, eventRout
 
 export function startTimeout() {
     forever('session-timeout', async () => {
-        while (true) {
-            // Find timed out sessions
-            const sessions = await db.session.findMany({
-                where: {
-                    active: true,
-                    lastActiveAt: {
-                        lte: new Date(Date.now() - 1000 * 60 * 10) // 10 minutes
-                    }
+        // Find timed out sessions
+        const sessions = await db.session.findMany({
+            where: {
+                active: true,
+                lastActiveAt: {
+                    lte: new Date(Date.now() - 1000 * 60 * 10) // 10 minutes
                 }
-            });
-            for (const session of sessions) {
-                const updated = await db.session.updateManyAndReturn({
-                    where: { id: session.id, active: true },
-                    data: { active: false }
-                });
-                if (updated.length === 0) {
-                    continue;
-                }
-                eventRouter.emitEphemeral({
-                    userId: session.accountId,
-                    payload: buildSessionActivityEphemeral(session.id, false, updated[0].lastActiveAt.getTime(), false),
-                    recipientFilter: { type: 'user-scoped-only' }
-                });
             }
-
-            // Find timed out machines
-            const machines = await db.machine.findMany({
-                where: {
-                    active: true,
-                    lastActiveAt: {
-                        lte: new Date(Date.now() - 1000 * 60 * 10) // 10 minutes
-                    }
-                }
+        });
+        for (const session of sessions) {
+            const updated = await db.session.updateManyAndReturn({
+                where: { id: session.id, active: true },
+                data: { active: false }
             });
-            for (const machine of machines) {
-                const updated = await db.machine.updateManyAndReturn({
-                    where: { id: machine.id, active: true },
-                    data: { active: false }
-                });
-                if (updated.length === 0) {
-                    continue;
-                }
-                eventRouter.emitEphemeral({
-                    userId: machine.accountId,
-                    payload: buildMachineActivityEphemeral(machine.id, false, updated[0].lastActiveAt.getTime()),
-                    recipientFilter: { type: 'user-scoped-only' }
-                });
+            if (updated.length === 0) {
+                continue;
             }
-
-            // Wait for 1 minute
-            await delay(1000 * 60, shutdownSignal);
+            eventRouter.emitEphemeral({
+                userId: session.accountId,
+                payload: buildSessionActivityEphemeral(session.id, false, updated[0].lastActiveAt.getTime(), false),
+                recipientFilter: { type: 'user-scoped-only' }
+            });
         }
+
+        // Find timed out machines
+        const machines = await db.machine.findMany({
+            where: {
+                active: true,
+                lastActiveAt: {
+                    lte: new Date(Date.now() - 1000 * 60 * 10) // 10 minutes
+                }
+            }
+        });
+        for (const machine of machines) {
+            const updated = await db.machine.updateManyAndReturn({
+                where: { id: machine.id, active: true },
+                data: { active: false }
+            });
+            if (updated.length === 0) {
+                continue;
+            }
+            eventRouter.emitEphemeral({
+                userId: machine.accountId,
+                payload: buildMachineActivityEphemeral(machine.id, false, updated[0].lastActiveAt.getTime()),
+                recipientFilter: { type: 'user-scoped-only' }
+            });
+        }
+
+        await delay(1000 * 60, shutdownSignal);
     });
 }

--- a/packages/happy-server/sources/main.ts
+++ b/packages/happy-server/sources/main.ts
@@ -20,7 +20,7 @@ async function main() {
     await db.$connect();
     onShutdown('db', async () => {
         await db.$disconnect();
-    });
+    }, 1);
     onShutdown('activity-cache', async () => {
         activityCache.shutdown();
     });
@@ -105,6 +105,7 @@ process.on('exit', (code) => {
         }, 'Process exiting normally');
     }
 });
+
 
 main().catch((e) => {
     console.error(e);

--- a/packages/happy-server/sources/utils/shutdown.ts
+++ b/packages/happy-server/sources/utils/shutdown.ts
@@ -1,13 +1,20 @@
 import { log } from "./log";
 
-const shutdownHandlers = new Map<string, Array<() => Promise<void>>>();
-const shutdownController = new AbortController();
+interface ShutdownEntry {
+    callback: () => Promise<void>;
+    phase: number;
+}
+
+const shutdownHandlers = new Map<string, ShutdownEntry[]>();
+export const shutdownController = new AbortController();
 
 export const shutdownSignal = shutdownController.signal;
 
-export function onShutdown(name: string, callback: () => Promise<void>): () => void {
+/**
+ * @param phase Lower phases execute first. Same-phase handlers run concurrently.
+ */
+export function onShutdown(name: string, callback: () => Promise<void>, phase = 0): () => void {
     if (shutdownSignal.aborted) {
-        // If already shutting down, execute immediately
         callback();
         return () => {};
     }
@@ -16,11 +23,11 @@ export function onShutdown(name: string, callback: () => Promise<void>): () => v
         shutdownHandlers.set(name, []);
     }
     const handlers = shutdownHandlers.get(name)!;
-    handlers.push(callback);
+    const entry: ShutdownEntry = { callback, phase };
+    handlers.push(entry);
     
-    // Return unsubscribe function
     return () => {
-        const index = handlers.indexOf(callback);
+        const index = handlers.indexOf(entry);
         if (index !== -1) {
             handlers.splice(index, 1);
             if (handlers.length === 0) {
@@ -47,36 +54,35 @@ export async function awaitShutdown() {
     });
     shutdownController.abort();
     
-    // Copy handlers to avoid race conditions
-    const handlersSnapshot = new Map<string, Array<() => Promise<void>>>();
-    for (const [name, handlers] of shutdownHandlers) {
-        handlersSnapshot.set(name, [...handlers]);
+    // Snapshot and group handlers by phase
+    const phaseMap = new Map<number, { name: string; callback: () => Promise<void> }[]>();
+    for (const [name, entries] of shutdownHandlers) {
+        for (const entry of entries) {
+            if (!phaseMap.has(entry.phase)) {
+                phaseMap.set(entry.phase, []);
+            }
+            phaseMap.get(entry.phase)!.push({ name, callback: entry.callback });
+        }
     }
     
-    // Execute all shutdown handlers concurrently
-    const allHandlers: Promise<void>[] = [];
-    let totalHandlers = 0;
+    const sortedPhases = [...phaseMap.keys()].sort((a, b) => a - b);
+    const startTime = Date.now();
     
-    for (const [name, handlers] of handlersSnapshot) {
-        totalHandlers += handlers.length;
-        log(`Starting ${handlers.length} shutdown handlers for: ${name}`);
+    for (const phase of sortedPhases) {
+        const handlers = phaseMap.get(phase)!;
+        log(`Phase ${phase}: starting ${handlers.length} shutdown handlers`);
         
-        handlers.forEach((handler, index) => {
-            const handlerPromise = handler().then(
+        const promises = handlers.map(({ name, callback }) =>
+            callback().then(
                 () => {},
-                (error) => log(`Error in shutdown handler ${name}[${index}]:`, error)
-            );
-            allHandlers.push(handlerPromise);
-        });
+                (error) => log(`Error in shutdown handler ${name}:`, error)
+            )
+        );
+        await Promise.all(promises);
     }
     
-    if (totalHandlers > 0) {
-        log(`Waiting for ${totalHandlers} shutdown handlers to complete...`);
-        const startTime = Date.now();
-        await Promise.all(allHandlers);
-        const duration = Date.now() - startTime;
-        log(`All ${totalHandlers} shutdown handlers completed in ${duration}ms`);
-    }
+    const duration = Date.now() - startTime;
+    log(`All shutdown handlers completed in ${duration}ms`);
 }
 
 export async function keepAlive<T>(name: string, callback: () => Promise<T>): Promise<T> {


### PR DESCRIPTION
## Summary

修复服务器关闭时的竞态条件问题，该问题导致 Prisma 在退出时报告错误。通过引入分阶段关闭机制，确保 keepAlive 操作在数据库断开连接之前完成。

## Changes

- **shutdown.ts**: 添加分阶段关闭机制
  - `onShutdown` 函数新增 `phase` 参数，支持按阶段顺序执行关闭处理器
  - 阶段数字越小越早执行，同阶段处理器并行执行
  - 将数据库断开连接设置为 phase 1，确保其他操作先完成

- **移除冗余的 while 循环**: 以下文件中的 `forever` 回调函数移除了多余的内部 `while (true)` 循环
  - `messageDelivery/timeout.ts`
  - `orchestrator/scheduler.ts`
  - `presence/timeout.ts`
  - （`forever` 函数本身已处理循环和关闭信号检查）

- **main.ts**: 将数据库关闭处理器设置为 phase 1

## Testing

- [x] 代码逻辑审查
- [x] 测试本地关闭流程
- [x] 验证 Prisma 错误不再出现
- [ ] 现有测试通过

## Related issues

Closes #