### PR TITLE
fix(dev): fix crash in dev screen when encryption is not initialized

### DIFF
--- a/packages/happy-app/sources/app/(app)/dev/index.tsx
+++ b/packages/happy-app/sources/app/(app)/dev/index.tsx
@@ -22,7 +22,7 @@ export default function DevScreen() {
     const [debugMode, setDebugMode] = useLocalSettingMutable('debugMode');
     const [verboseLogging, setVerboseLogging] = React.useState(false);
     const socketStatus = useSocketStatus();
-    const anonymousId = sync.encryption!.anonID;
+    const anonymousId = sync.encryption?.anonID || 'N/A';
     const { theme } = useUnistyles();
 
     const handleEditServerUrl = async () => {


### PR DESCRIPTION
Prevents TypeError: Cannot read property 'anonID' of undefined when accessing sync.encryption before authentication is complete.

## Summary

修复 Dev 屏幕在加密模块未初始化时的崩溃问题。当认证尚未完成时访问 `sync.encryption` 会导致 TypeError。

## Changes

- `packages/happy-app/sources/app/(app)/dev/index.tsx`: 使用可选链操作符 `?.` 替代非空断言 `!`，并提供默认值 `'N/A'`

## Testing

How was this tested?

- [ ] Tested locally
- [ ] Existing tests pass
- [ ] New tests added (if applicable)

## Related issues

Closes #
