### PR TITLE
fix(cli): respect HAPPY_HOME_DIR env var in happy-dev

### DIFF
--- a/packages/happy-cli/bin/happy-dev.mjs
+++ b/packages/happy-cli/bin/happy-dev.mjs
@@ -15,7 +15,7 @@ if (!hasNoWarnings || !hasNoDeprecation) {
   const scriptPath = join(dirname(__filename), '../dist/index.mjs');
 
   // Set development environment variables
-  process.env.HAPPY_HOME_DIR = join(homedir(), '.happy-dev');
+  process.env.HAPPY_HOME_DIR = process.env.HAPPY_HOME_DIR || join(homedir(), '.happy-next-dev');
   process.env.HAPPY_VARIANT = 'dev';
 
   try {
@@ -34,7 +34,7 @@ if (!hasNoWarnings || !hasNoDeprecation) {
 } else {
   // Already have the flags, import normally
   // Set development environment variables
-  process.env.HAPPY_HOME_DIR = join(homedir(), '.happy-dev');
+  process.env.HAPPY_HOME_DIR = process.env.HAPPY_HOME_DIR || join(homedir(), '.happy-next-dev');
   process.env.HAPPY_VARIANT = 'dev';
 
   await import('../dist/index.mjs');


### PR DESCRIPTION
## Summary

修复 happy-dev 命令不尊重外部 HAPPY_HOME_DIR 环境变量的问题，并将默认 dev 数据目录从 ~/.happy-dev 改为 ~/.happy-next-dev 以与项目名称保持一致。

## Changes

- 修改 packages/happy-cli/bin/happy-dev.mjs
  - 允许外部 HAPPY_HOME_DIR 环境变量覆盖默认值
  - 将默认 dev 目录从 ~/.happy-dev 改为 ~/.happy-next-dev

## Testing

How was this tested?

- [x] Tested locally
- [ ] Existing tests pass
- [ ] New tests added (if applicable)


## 测试步骤 :

1. 设置 export HAPPY_HOME_DIR=~/.happy-next-dev
2. 运行 happy-dev
3. 验证 CLI 显示 🔧 DEV MODE - Data: /Users/lms/.happy-next-dev

## Related issues

Closes #
