### PR TITLE
fix: permission mode change not taking effect mid-session

### DIFF
--- a/packages/happy-app/sources/sync/storage.ts
+++ b/packages/happy-app/sources/sync/storage.ts
@@ -1403,7 +1403,7 @@ export const storage = create<StorageState>()((set, get) => {
             if (!session) return;
             const flavor = session.metadata?.flavor;
             const agentType = resolveSessionModeAgentType(flavor);
-            if (flavor === 'claude' || flavor === 'gemini') {
+            if (flavor === 'claude' || flavor === 'gemini' || flavor === 'codex') {
                 void sync.changePermissionMode(sessionId, mode);
             }
             set((state) => {

--- a/packages/happy-cli/src/claude/claudeRemoteLauncher.ts
+++ b/packages/happy-cli/src/claude/claudeRemoteLauncher.ts
@@ -137,7 +137,7 @@ export async function claudeRemoteLauncher(session: Session): Promise<'switch' |
 
     // Create permission handler
     const permissionHandler = new PermissionHandler(session);
-    const validPermissionModes: PermissionMode[] = ['default', 'acceptEdits', 'bypassPermissions', 'plan'];
+    const validPermissionModes: PermissionMode[] = ['default', 'acceptEdits', 'bypassPermissions', 'plan', 'yolo'];
 
     session.client.rpcHandlerManager.registerHandler<{ mode?: PermissionMode }, boolean>(
         'permission-mode-changed',


### PR DESCRIPTION


## Summary

修复会话中切换权限模式（permission mode）不实时生效的问题。


## Changes

- packages/happy-cli/src/claude/claudeRemoteLauncher.ts: permission-mode-changed RPC handler 的 validPermissionModes 列表缺少 'yolo'，导致 App 发送该模式时被验证拦截，handleModeChange 未执行
- packages/happy-app/sources/sync/storage.ts: updateSessionPermissionMode() 仅对 claude/gemini 触发 RPC，遗漏了 codex

## Testing

How was this tested?

- [x] Tested locally
- [x] Existing tests pass
- [ ] New tests added (if applicable)

## Related issues

N/A
