### PR TITLE
fix(cli): correct clone directory name in CONTRIBUTING.md Getting Started

### DIFF
--- a/packages/happy-cli/CONTRIBUTING.md
+++ b/packages/happy-cli/CONTRIBUTING.md
@@ -11,7 +11,7 @@
 
 ```bash
 git clone https://github.com/hitosea/happy-next.git
-cd happy/packages/happy-cli
+cd happy-next/packages/happy-cli
 yarn install
 yarn build
 ```


### PR DESCRIPTION

## Summary

Fix incorrect cd directory name in CONTRIBUTING.md Getting Started section.

## Changes

- Change cd happy/packages/happy-cli to cd happy-next/packages/happy-cli to match the cloned repository directory name from the git clone URL

## Testing

How was this tested?

- [x] Tested locally
- [x] Existing tests pass
- [ ] New tests added (if applicable)

## Related issues

N/A
