### PR TITLE
chore: add .worktrees/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ yarn-error.*
 CLAUDE.local.md
 
 .dev/worktree/*
+.worktrees/
 
 # Development planning notes (keep local, don't commit)
 notes/


### PR DESCRIPTION
## Summary

Add `.worktrees/` directory to `.gitignore` for git worktree isolation.

## Changes

- Add `.worktrees/` entry to root `.gitignore` alongside the existing `.dev/worktree/*` pattern

## Testing

How was this tested?

- [x] Tested locally
- [x] Existing tests pass
- [ ] New tests added (if applicable)

## Related issues

N/A
