### PR TITLE
fix(cli): prevent transient image download failures from killing sessions

### DIFF
--- a/packages/happy-cli/src/claude/claudeRemote.ts
+++ b/packages/happy-cli/src/claude/claudeRemote.ts
@@ -206,21 +206,32 @@ export async function claudeRemote(opts: {
         }
         awaitingNextUserMessage = true;
         try {
-            const next = await opts.nextMessage();
-            if (!next) {
-                streamEnded = true;
-                messages.end();
-                return;
-            }
-            mode = next.mode;
-            const messageContent = await toClaudeMessageContent(next.message);
-            messages.push({
-                type: 'user',
-                message: {
-                    role: 'user',
-                    content: messageContent
+            while (!streamEnded) {
+                const next = await opts.nextMessage();
+                if (!next) {
+                    streamEnded = true;
+                    messages.end();
+                    return;
                 }
-            });
+                mode = next.mode;
+                try {
+                    const messageContent = await toClaudeMessageContent(next.message);
+                    messages.push({
+                        type: 'user',
+                        message: {
+                            role: 'user',
+                            content: messageContent
+                        }
+                    });
+                    return;
+                } catch (formatError) {
+                    logger.debug('[claudeRemote] Failed to format user message', formatError);
+                    if (opts.onCompletionEvent) {
+                        opts.onCompletionEvent('Failed to process message attachments. Please try again.');
+                    }
+                    opts.onReady();
+                }
+            }
         } catch (error) {
             logger.debug('[claudeRemote] Failed to fetch next user message', error);
             streamEnded = true;

--- a/packages/happy-cli/src/utils/downloadImage.ts
+++ b/packages/happy-cli/src/utils/downloadImage.ts
@@ -1,4 +1,9 @@
 import axios from 'axios';
+import { delay } from '@/utils/time';
+import { logger } from '@/ui/logger';
+
+const MAX_RETRIES = 3;
+const RETRY_DELAYS = [1000, 2000, 4000];
 
 interface DownloadedImage {
     base64: string;
@@ -9,18 +14,29 @@ interface DownloadedImage {
  * Downloads an image from URL and returns it as base64.
  */
 export async function downloadImage(url: string): Promise<DownloadedImage> {
-    const response = await axios.get(url, {
-        responseType: 'arraybuffer',
-    });
+    let lastError: unknown;
+    for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+        try {
+            const response = await axios.get(url, {
+                responseType: 'arraybuffer',
+            });
 
-    const buffer = Buffer.from(response.data);
-    const base64 = buffer.toString('base64');
+            const buffer = Buffer.from(response.data);
+            const base64 = buffer.toString('base64');
 
-    // Determine mime type from response headers or URL
-    let mimeType = response.headers['content-type'] || 'image/jpeg';
-    if (mimeType.includes(';')) {
-        mimeType = mimeType.split(';')[0].trim();
+            let mimeType = response.headers['content-type'] || 'image/jpeg';
+            if (mimeType.includes(';')) {
+                mimeType = mimeType.split(';')[0].trim();
+            }
+
+            return { base64, mimeType };
+        } catch (error) {
+            lastError = error;
+            if (attempt < MAX_RETRIES) {
+                logger.debug(`[downloadImage] Attempt ${attempt + 1}/${MAX_RETRIES + 1} failed for ${url}, retrying in ${RETRY_DELAYS[attempt]}ms`, error);
+                await delay(RETRY_DELAYS[attempt]);
+            }
+        }
     }
-
-    return { base64, mimeType };
+    throw lastError;
 }


### PR DESCRIPTION
## Summary

修复图片下载的瞬态失败导致整个 CLI 会话崩溃的问题。为图片下载添加重试机制，并在消息格式化失败时优雅恢复而非终止会话。

## Changes

- downloadImage.ts：添加最多 3 次重试 + 指数退避延迟（1s, 2s, 4s），瞬态网络错误不再直接抛出
- claudeRemote.ts：toClaudeMessageContent 失败时捕获错误，向用户提示 "Failed to process message attachments"，并允许用户重新发送消息，而非终止整个会话流

## Testing

How was this tested?

- [ ] Tested locally
- [ ] Existing tests pass
- [ ] New tests added (if applicable)

## Related issues

Closes #

N/A