### PR TITLE
feat(codex): add skill autocomplete

### DIFF
--- a/packages/happy-app/sources/-session/SessionView.tsx
+++ b/packages/happy-app/sources/-session/SessionView.tsx
@@ -865,7 +865,7 @@ function SessionViewLoaded({ sessionId, session }: { sessionId: string, session:
             showAbortButton={sessionStatus.state === 'thinking' || sessionStatus.state === 'waiting'}
             onFileViewerPress={() => router.push(`/session/${sessionId}/files`)}
             // Autocomplete configuration
-            autocompletePrefixes={['@', '/']}
+            autocompletePrefixes={(session.metadata?.flavor === 'codex' || session.metadata?.codexSessionId) ? ['@', '/', '$'] : ['@', '/']}
             autocompleteSuggestions={(query) => getSuggestions(sessionId, query)}
             usageData={sessionUsage ? {
                 inputTokens: sessionUsage.inputTokens,

--- a/packages/happy-app/sources/components/AgentInputSuggestionView.tsx
+++ b/packages/happy-app/sources/components/AgentInputSuggestionView.tsx
@@ -30,6 +30,48 @@ export const CommandSuggestion = React.memo(({ command, description }: CommandSu
     );
 });
 
+interface SkillSuggestionProps {
+    name: string;
+    description?: string;
+    scope: 'REPO' | 'USER' | 'ADMIN' | 'SYSTEM';
+    displayName?: string;
+}
+
+export const SkillSuggestion = React.memo(({ name, description, scope, displayName }: SkillSuggestionProps) => {
+    return (
+        <View style={styles.suggestionContainer}>
+            <View style={styles.skillIconContainer}>
+                <Ionicons
+                    name="cube-outline"
+                    size={18}
+                    color={styles.iconColor.color}
+                />
+            </View>
+            <Text
+                style={[styles.commandText, { marginRight: description ? 12 : 0 }]}
+                numberOfLines={1}
+            >
+                {displayName || name}
+            </Text>
+            {description && (
+                <Text
+                    style={styles.descriptionText}
+                    numberOfLines={1}
+                >
+                    {description}
+                </Text>
+            )}
+            <Text style={styles.labelText}>
+                {scope === 'REPO'
+                    ? t('agentInput.suggestion.skillScopeRepo')
+                    : scope === 'USER'
+                        ? t('agentInput.suggestion.skillScopePersonal')
+                        : t('agentInput.suggestion.skillScopeSystem')}
+            </Text>
+        </View>
+    );
+});
+
 interface FileMentionProps {
     fileName: string;
     filePath: string;
@@ -80,6 +122,15 @@ const styles = StyleSheet.create((theme) => ({
         ...Typography.default(),
     },
     iconContainer: {
+        width: 32,
+        height: 32,
+        borderRadius: 16,
+        backgroundColor: theme.colors.surfaceHigh,
+        alignItems: 'center',
+        justifyContent: 'center',
+        marginRight: 12,
+    },
+    skillIconContainer: {
         width: 32,
         height: 32,
         borderRadius: 16,

--- a/packages/happy-app/sources/components/autocomplete/suggestions.ts
+++ b/packages/happy-app/sources/components/autocomplete/suggestions.ts
@@ -1,21 +1,19 @@
-import { CommandSuggestion, FileMentionSuggestion } from '@/components/AgentInputSuggestionView';
+import { CommandSuggestion, FileMentionSuggestion, SkillSuggestion } from '@/components/AgentInputSuggestionView';
 import * as React from 'react';
 import { searchFiles, FileItem } from '@/sync/suggestionFile';
 import { searchCommands, CommandItem } from '@/sync/suggestionCommands';
+import { searchSkills, SkillItem } from '@/sync/suggestionSkills';
 
 export async function getCommandSuggestions(sessionId: string, query: string): Promise<{
     key: string;
     text: string;
     component: React.ComponentType;
 }[]> {
-    // Remove the "/" prefix for searching
     const searchTerm = query.slice(1);
-    
+
     try {
-        // Use the command search cache with fuzzy matching
         const commands = await searchCommands(sessionId, searchTerm, { limit: 5 });
-        
-        // Convert CommandItem to suggestion format
+
         return commands.map((cmd: CommandItem) => ({
             key: `cmd-${cmd.command}`,
             text: `/${cmd.command}`,
@@ -26,7 +24,32 @@ export async function getCommandSuggestions(sessionId: string, query: string): P
         }));
     } catch (error) {
         console.error('Error fetching command suggestions:', error);
-        // Return empty array on error
+        return [];
+    }
+}
+
+export async function getSkillSuggestions(sessionId: string, query: string): Promise<{
+    key: string;
+    text: string;
+    component: React.ComponentType;
+}[]> {
+    const searchTerm = query.slice(1);
+
+    try {
+        const skills = await searchSkills(sessionId, searchTerm);
+
+        return skills.map((skill: SkillItem) => ({
+            key: `skill-${skill.scope}-${skill.path}`,
+            text: `$${skill.name}`,
+            component: () => React.createElement(SkillSuggestion, {
+                name: skill.name,
+                description: skill.shortDescription || skill.description,
+                scope: skill.scope,
+                displayName: skill.displayName,
+            })
+        }));
+    } catch (error) {
+        console.error('Error fetching skill suggestions:', error);
         return [];
     }
 }
@@ -36,17 +59,14 @@ export async function getFileMentionSuggestions(sessionId: string, query: string
     text: string;
     component: React.ComponentType;
 }[]> {
-    // Remove the "@" prefix for searching
     const searchTerm = query.slice(1);
-    
+
     try {
-        // Use the file search cache with fuzzy matching
         const files = await searchFiles(sessionId, searchTerm, { limit: 5 });
-        
-        // Convert FileItem to suggestion format
+
         return files.map((file: FileItem) => ({
             key: `file-${file.fullPath}`,
-            text: `@${file.fullPath}`,  // Full path in the mention
+            text: `@${file.fullPath}`,
             component: () => React.createElement(FileMentionSuggestion, {
                 fileName: file.fileName,
                 filePath: file.filePath,
@@ -55,7 +75,6 @@ export async function getFileMentionSuggestions(sessionId: string, query: string
         }));
     } catch (error) {
         console.error('Error fetching file suggestions:', error);
-        // Return empty array on error
         return [];
     }
 }
@@ -65,38 +84,21 @@ export async function getSuggestions(sessionId: string, query: string): Promise<
     text: string;
     component: React.ComponentType;
 }[]> {
-    console.log('💡 getSuggestions called with query:', JSON.stringify(query));
-    
     if (!query || query.length === 0) {
-        console.log('💡 getSuggestions: Empty query, returning empty array');
         return [];
     }
-    
-    // Check if it's a command (starts with /)
+
     if (query.startsWith('/')) {
-        console.log('💡 getSuggestions: Command detected');
-        const result = await getCommandSuggestions(sessionId, query);
-        console.log('💡 getSuggestions: Command suggestions:', JSON.stringify(result.map(r => ({
-            key: r.key,
-            text: r.text,
-            component: '[Function]'
-        })), null, 2));
-        return result;
+        return getCommandSuggestions(sessionId, query);
     }
-    
-    // Check if it's a file mention (starts with @)
+
+    if (query.startsWith('$')) {
+        return getSkillSuggestions(sessionId, query);
+    }
+
     if (query.startsWith('@')) {
-        console.log('💡 getSuggestions: File mention detected');
-        const result = await getFileMentionSuggestions(sessionId, query);
-        console.log('💡 getSuggestions: File suggestions:', JSON.stringify(result.map(r => ({
-            key: r.key,
-            text: r.text,
-            component: '[Function]'
-        })), null, 2));
-        return result;
+        return getFileMentionSuggestions(sessionId, query);
     }
-    
-    // No suggestions for other queries
-    console.log('💡 getSuggestions: No matching prefix, returning empty array');
+
     return [];
 }

--- a/packages/happy-app/sources/sync/storageTypes.ts
+++ b/packages/happy-app/sources/sync/storageTypes.ts
@@ -41,6 +41,14 @@ export const MetadataSchema = z.object({
     codexSessionId: z.string().optional(), // Codex CLI conversation ID
     tools: z.array(z.string()).optional(),
     slashCommands: z.array(z.string()).optional(),
+    skills: z.array(z.object({
+        name: z.string(),
+        description: z.string(),
+        scope: z.enum(['REPO', 'USER', 'ADMIN', 'SYSTEM']),
+        path: z.string(),
+        displayName: z.string().optional(),
+        shortDescription: z.string().optional(),
+    })).optional(),
     homeDir: z.string().optional(), // User's home directory on the machine
     happyHomeDir: z.string().optional(), // Happy configuration directory 
     hostPid: z.number().optional(), // Process ID of the session

--- a/packages/happy-app/sources/sync/suggestionSkills.ts
+++ b/packages/happy-app/sources/sync/suggestionSkills.ts
@@ -1,0 +1,65 @@
+/**
+ * Suggestion skills functionality for Codex `$skill` mentions.
+ * Reads discovered skills from session metadata.
+ */
+
+import Fuse from 'fuse.js';
+import { getSession } from './storage';
+
+export type SkillScope = 'REPO' | 'USER' | 'ADMIN' | 'SYSTEM';
+
+export interface SkillItem {
+    name: string;
+    description: string;
+    scope: SkillScope;
+    path: string;
+    displayName?: string;
+    shortDescription?: string;
+}
+
+interface SearchOptions {
+    limit?: number;
+    threshold?: number;
+}
+
+function getSkillsFromSession(sessionId: string): SkillItem[] {
+    const session = getSession(sessionId);
+    if (!session?.metadata?.skills) {
+        return [];
+    }
+
+    return session.metadata.skills;
+}
+
+export async function searchSkills(
+    sessionId: string,
+    query: string,
+    options: SearchOptions = {}
+): Promise<SkillItem[]> {
+    const { limit, threshold = 0.35 } = options;
+    const skills = getSkillsFromSession(sessionId);
+
+    if (!query || query.trim().length === 0) {
+        return limit ? skills.slice(0, limit) : skills;
+    }
+
+    const fuse = new Fuse(skills, {
+        keys: [
+            { name: 'name', weight: 0.45 },
+            { name: 'displayName', weight: 0.25 },
+            { name: 'description', weight: 0.2 },
+            { name: 'shortDescription', weight: 0.1 },
+        ],
+        threshold,
+        includeScore: true,
+        shouldSort: true,
+        minMatchCharLength: 1,
+        ignoreLocation: true,
+    });
+
+    return fuse.search(query, limit ? { limit } : undefined).map(result => result.item);
+}
+
+export function getAllSkills(sessionId: string): SkillItem[] {
+    return getSkillsFromSession(sessionId);
+}

--- a/packages/happy-app/sources/text/_default.ts
+++ b/packages/happy-app/sources/text/_default.ts
@@ -969,6 +969,9 @@ export const en = {
         suggestion: {
             fileLabel: 'FILE',
             folderLabel: 'FOLDER',
+            skillScopeRepo: 'REPO',
+            skillScopePersonal: 'USER',
+            skillScopeSystem: 'SYSTEM',
         },
         noMachinesAvailable: 'No machines',
     },

--- a/packages/happy-app/sources/text/translations/ca.ts
+++ b/packages/happy-app/sources/text/translations/ca.ts
@@ -955,6 +955,9 @@ export const ca: TranslationStructure = {
         suggestion: {
             fileLabel: 'FITXER',
             folderLabel: 'CARPETA',
+            skillScopeRepo: 'REPO',
+            skillScopePersonal: 'USUARI',
+            skillScopeSystem: 'SISTEMA',
         },
         noMachinesAvailable: 'Sense màquines',
     },

--- a/packages/happy-app/sources/text/translations/en.ts
+++ b/packages/happy-app/sources/text/translations/en.ts
@@ -972,6 +972,9 @@ export const en: TranslationStructure = {
         suggestion: {
             fileLabel: 'FILE',
             folderLabel: 'FOLDER',
+            skillScopeRepo: 'REPO',
+            skillScopePersonal: 'USER',
+            skillScopeSystem: 'SYSTEM',
         },
         noMachinesAvailable: 'No machines',
     },

--- a/packages/happy-app/sources/text/translations/es.ts
+++ b/packages/happy-app/sources/text/translations/es.ts
@@ -955,6 +955,9 @@ export const es: TranslationStructure = {
         suggestion: {
             fileLabel: 'ARCHIVO',
             folderLabel: 'CARPETA',
+            skillScopeRepo: 'REPO',
+            skillScopePersonal: 'USUARIO',
+            skillScopeSystem: 'SISTEMA',
         },
         noMachinesAvailable: 'Sin máquinas',
     },

--- a/packages/happy-app/sources/text/translations/it.ts
+++ b/packages/happy-app/sources/text/translations/it.ts
@@ -985,6 +985,9 @@ export const it: TranslationStructure = {
         suggestion: {
             fileLabel: 'FILE',
             folderLabel: 'CARTELLA',
+            skillScopeRepo: 'REPO',
+            skillScopePersonal: 'UTENTE',
+            skillScopeSystem: 'SISTEMA',
         },
         noMachinesAvailable: 'Nessuna macchina',
     },

--- a/packages/happy-app/sources/text/translations/ja.ts
+++ b/packages/happy-app/sources/text/translations/ja.ts
@@ -987,6 +987,9 @@ export const ja: TranslationStructure = {
         suggestion: {
             fileLabel: 'ファイル',
             folderLabel: 'フォルダ',
+            skillScopeRepo: 'リポジトリ',
+            skillScopePersonal: '個人',
+            skillScopeSystem: 'システム',
         },
         noMachinesAvailable: 'マシンなし',
     },

--- a/packages/happy-app/sources/text/translations/pl.ts
+++ b/packages/happy-app/sources/text/translations/pl.ts
@@ -966,6 +966,9 @@ export const pl: TranslationStructure = {
         suggestion: {
             fileLabel: 'PLIK',
             folderLabel: 'FOLDER',
+            skillScopeRepo: 'REPO',
+            skillScopePersonal: 'UŻYTK',
+            skillScopeSystem: 'SYSTEM',
         },
         noMachinesAvailable: 'Brak maszyn',
     },

--- a/packages/happy-app/sources/text/translations/pt.ts
+++ b/packages/happy-app/sources/text/translations/pt.ts
@@ -955,6 +955,9 @@ export const pt: TranslationStructure = {
         suggestion: {
             fileLabel: 'ARQUIVO',
             folderLabel: 'PASTA',
+            skillScopeRepo: 'REPO',
+            skillScopePersonal: 'USUÁRIO',
+            skillScopeSystem: 'SISTEMA',
         },
         noMachinesAvailable: 'Sem máquinas',
     },

--- a/packages/happy-app/sources/text/translations/ru.ts
+++ b/packages/happy-app/sources/text/translations/ru.ts
@@ -966,6 +966,9 @@ export const ru: TranslationStructure = {
         suggestion: {
             fileLabel: 'ФАЙЛ',
             folderLabel: 'ПАПКА',
+            skillScopeRepo: 'РЕПО',
+            skillScopePersonal: 'ПОЛЬЗ',
+            skillScopeSystem: 'СИСТ',
         },
         noMachinesAvailable: 'Нет машин',
     },

--- a/packages/happy-app/sources/text/translations/zh-Hans.ts
+++ b/packages/happy-app/sources/text/translations/zh-Hans.ts
@@ -957,6 +957,9 @@ export const zhHans: TranslationStructure = {
         suggestion: {
             fileLabel: '文件',
             folderLabel: '文件夹',
+            skillScopeRepo: '项目',
+            skillScopePersonal: '个人',
+            skillScopeSystem: '系统',
         },
         noMachinesAvailable: '无设备',
     },

--- a/packages/happy-app/sources/text/translations/zh-Hant.ts
+++ b/packages/happy-app/sources/text/translations/zh-Hant.ts
@@ -957,6 +957,9 @@ export const zhHant: TranslationStructure = {
         suggestion: {
             fileLabel: '檔案',
             folderLabel: '資料夾',
+            skillScopeRepo: '專案',
+            skillScopePersonal: '個人',
+            skillScopeSystem: '系統',
         },
         noMachinesAvailable: '無裝置',
     },

--- a/packages/happy-cli/src/api/types.ts
+++ b/packages/happy-cli/src/api/types.ts
@@ -347,6 +347,14 @@ export type Metadata = {
   claudeSessionId?: string, // Claude Code session ID
   tools?: string[],
   slashCommands?: string[],
+  skills?: Array<{
+    name: string,
+    description: string,
+    scope: 'REPO' | 'USER' | 'ADMIN' | 'SYSTEM',
+    path: string,
+    displayName?: string,
+    shortDescription?: string,
+  }>,
   homeDir: string,
   happyHomeDir: string,
   happyLibDir: string,

--- a/packages/happy-cli/src/codex/runCodex.ts
+++ b/packages/happy-cli/src/codex/runCodex.ts
@@ -19,6 +19,7 @@ import { MessageQueue2 } from '@/utils/MessageQueue2';
 import { hashObject } from '@/utils/deterministicJson';
 import { createMcpContext } from '@/agent/mcp';
 import { createSessionMetadata } from '@/utils/createSessionMetadata';
+import { discoverCodexSkills, getCodexSkillsSignature } from './utils/skillDiscovery';
 import { MessageBuffer } from "@/ui/ink/messageBuffer";
 import { CodexDisplay } from "@/ui/ink/CodexDisplay";
 // trimIdent not currently used
@@ -173,10 +174,12 @@ export async function runCodex(opts: {
     // Create session
     //
 
+    const skills = discoverCodexSkills();
     const { state, metadata } = createSessionMetadata({
         flavor: 'codex',
         machineId,
-        startedBy: opts.startedBy
+        startedBy: opts.startedBy,
+        skills,
     });
     const response = await api.getOrCreateSession({ tag: sessionTag, metadata, state });
 
@@ -197,6 +200,29 @@ export async function runCodex(opts: {
         }
     });
     session = initialSession;
+
+    // Keep Happy's remote autocomplete aligned with Codex Desktop/CLI skill discovery.
+    // Codex can pick up new skills during a session (for example after $skill-installer),
+    // so periodically rescan, but only write metadata when the skill list changed.
+    let lastSkillsSignature = getCodexSkillsSignature(skills);
+    const skillRefreshInterval = setInterval(() => {
+        try {
+            const nextSkills = discoverCodexSkills();
+            const nextSignature = getCodexSkillsSignature(nextSkills);
+            if (nextSignature === lastSkillsSignature) {
+                return;
+            }
+
+            lastSkillsSignature = nextSignature;
+            session.updateMetadata((currentMetadata) => ({
+                ...currentMetadata,
+                skills: nextSkills,
+            }));
+        } catch (error) {
+            logger.debug('[codex] Failed to refresh skills metadata:', error);
+        }
+    }, 30_000);
+    skillRefreshInterval.unref?.();
 
     // Set initial session title if provided (e.g. review sessions)
     const sessionTitle = process.env.HAPPY_SESSION_TITLE?.trim();
@@ -1212,6 +1238,7 @@ export async function runCodex(opts: {
         }
         logger.debug('[codex]: clearInterval(keepAlive)');
         clearInterval(keepAliveInterval);
+        clearInterval(skillRefreshInterval);
         if (inkInstance) {
             logger.debug('[codex]: inkInstance.unmount()');
             inkInstance.unmount();

--- a/packages/happy-cli/src/codex/utils/skillDiscovery.ts
+++ b/packages/happy-cli/src/codex/utils/skillDiscovery.ts
@@ -1,0 +1,211 @@
+import { execFileSync } from 'node:child_process';
+import { readdirSync, readFileSync, realpathSync } from 'node:fs';
+import os from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+
+export type CodexSkillScope = 'REPO' | 'USER' | 'ADMIN' | 'SYSTEM';
+
+export interface CodexSkillMetadata {
+    name: string;
+    description: string;
+    scope: CodexSkillScope;
+    path: string;
+    displayName?: string;
+    shortDescription?: string;
+}
+
+export function getCodexSkillsSignature(skills: CodexSkillMetadata[]): string {
+    return JSON.stringify(
+        skills
+            .map(skill => ({
+                name: skill.name,
+                description: skill.description,
+                scope: skill.scope,
+                path: normalizePath(skill.path),
+                displayName: skill.displayName ?? null,
+                shortDescription: skill.shortDescription ?? null,
+            }))
+            .sort((a, b) => {
+                const scopeCompare = a.scope.localeCompare(b.scope);
+                if (scopeCompare !== 0) return scopeCompare;
+                const pathCompare = a.path.localeCompare(b.path);
+                if (pathCompare !== 0) return pathCompare;
+                return a.name.localeCompare(b.name);
+            })
+    );
+}
+
+function findGitRoot(cwd: string): string {
+    try {
+        return execFileSync('git', ['rev-parse', '--show-toplevel'], {
+            cwd,
+            encoding: 'utf8',
+            timeout: 1000,
+            stdio: ['ignore', 'pipe', 'ignore'],
+        }).trim() || cwd;
+    } catch {
+        return cwd;
+    }
+}
+
+function collectAncestors(from: string, until: string): string[] {
+    const result: string[] = [];
+    let current = resolve(from);
+    const stop = resolve(until);
+
+    while (true) {
+        result.push(current);
+        if (current === stop) break;
+        const parent = dirname(current);
+        if (parent === current) break;
+        current = parent;
+    }
+
+    return result;
+}
+
+function parseFrontmatter(markdown: string): Record<string, string> | null {
+    const match = markdown.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+    if (!match) return null;
+
+    const values: Record<string, string> = {};
+    for (const line of match[1].split(/\r?\n/)) {
+        const colonIndex = line.indexOf(':');
+        if (colonIndex <= 0) continue;
+        const key = line.slice(0, colonIndex).trim();
+        let value = line.slice(colonIndex + 1).trim();
+        if (
+            (value.startsWith('"') && value.endsWith('"')) ||
+            (value.startsWith("'") && value.endsWith("'"))
+        ) {
+            value = value.slice(1, -1);
+        }
+        values[key] = value;
+    }
+    return values;
+}
+
+function parseOpenAiYaml(skillDir: string): Pick<CodexSkillMetadata, 'displayName' | 'shortDescription'> {
+    const metadataPath = join(skillDir, 'agents', 'openai.yaml');
+
+    try {
+        const yaml = readFileSync(metadataPath, 'utf8');
+        const displayName = yaml.match(/^\s*display_name:\s*["']?(.+?)["']?\s*$/m)?.[1];
+        const shortDescription = yaml.match(/^\s*short_description:\s*["']?(.+?)["']?\s*$/m)?.[1];
+        const result: Pick<CodexSkillMetadata, 'displayName' | 'shortDescription'> = {};
+        if (displayName) result.displayName = displayName;
+        if (shortDescription) result.shortDescription = shortDescription;
+        return result;
+    } catch {
+        return {};
+    }
+}
+
+function readSkill(skillDir: string, scope: CodexSkillScope): CodexSkillMetadata | null {
+    const skillPath = join(skillDir, 'SKILL.md');
+
+    try {
+        const markdown = readFileSync(skillPath, 'utf8');
+        const frontmatter = parseFrontmatter(markdown);
+        const name = frontmatter?.name?.trim();
+        const description = frontmatter?.description?.trim();
+        if (!name || !description) return null;
+
+        const uiMetadata = parseOpenAiYaml(skillDir);
+        return {
+            name,
+            description,
+            scope,
+            path: skillPath,
+            ...uiMetadata,
+        };
+    } catch {
+        return null;
+    }
+}
+
+function scanSkillRoot(root: string, scope: CodexSkillScope, includeDotDirs = true): CodexSkillMetadata[] {
+    const skills: CodexSkillMetadata[] = [];
+    try {
+        for (const entry of readdirSync(root, { withFileTypes: true })) {
+            if (!entry.isDirectory() && !entry.isSymbolicLink()) continue;
+            if (!includeDotDirs && entry.name.startsWith('.')) continue;
+
+            const skillDir = join(root, entry.name);
+            const skill = readSkill(skillDir, scope);
+            if (skill) {
+                skills.push(skill);
+            }
+        }
+    } catch {
+        // Ignore unreadable skill roots.
+    }
+
+    return skills;
+}
+
+function normalizePath(path: string): string {
+    try {
+        return realpathSync(path);
+    } catch {
+        return resolve(path);
+    }
+}
+
+function readDisabledSkillPaths(homeDir: string): Set<string> {
+    const disabled = new Set<string>();
+    const configPath = join(homeDir, '.codex', 'config.toml');
+
+    try {
+        const config = readFileSync(configPath, 'utf8');
+        const blocks = config.split(/\[\[skills\.config\]\]/g).slice(1);
+        for (const block of blocks) {
+            const path = block.match(/^\s*path\s*=\s*["'](.+?)["']\s*$/m)?.[1];
+            const enabled = block.match(/^\s*enabled\s*=\s*(true|false)\s*$/m)?.[1];
+            if (path && enabled === 'false') {
+                disabled.add(normalizePath(path));
+            }
+        }
+    } catch {
+        // Ignore malformed or unreadable config.
+    }
+
+    return disabled;
+}
+
+function pushUniqueRoot(roots: string[], root: string): void {
+    try {
+        const normalized = realpathSync(root);
+        if (!roots.includes(normalized)) roots.push(normalized);
+    } catch {
+        const normalized = resolve(root);
+        if (!roots.includes(normalized)) roots.push(normalized);
+    }
+}
+
+export function discoverCodexSkills(cwd = process.cwd(), homeDir = os.homedir()): CodexSkillMetadata[] {
+    const skills: CodexSkillMetadata[] = [];
+    const disabledSkillPaths = readDisabledSkillPaths(homeDir);
+
+    const repoRoot = findGitRoot(cwd);
+    const repoSkillRoots: string[] = [];
+    for (const ancestor of collectAncestors(cwd, repoRoot)) {
+        // Codex docs use .agents/skills for repo skills. Team Config also exposes .codex/skills,
+        // so scan both and label both as REPO in the UI.
+        pushUniqueRoot(repoSkillRoots, join(ancestor, '.agents', 'skills'));
+        pushUniqueRoot(repoSkillRoots, join(ancestor, '.codex', 'skills'));
+    }
+    for (const root of repoSkillRoots) {
+        skills.push(...scanSkillRoot(root, 'REPO'));
+    }
+
+    // Official Codex location is ~/.agents/skills. Keep ~/.codex/skills for compatibility
+    // with older local setups, excluding dot folders so ~/.codex/skills/.system stays SYSTEM.
+    skills.push(...scanSkillRoot(join(homeDir, '.agents', 'skills'), 'USER'));
+    skills.push(...scanSkillRoot(join(homeDir, '.codex', 'skills'), 'USER', false));
+
+    skills.push(...scanSkillRoot('/etc/codex/skills', 'ADMIN'));
+    skills.push(...scanSkillRoot(join(homeDir, '.codex', 'skills', '.system'), 'SYSTEM'));
+
+    return skills.filter(skill => !disabledSkillPaths.has(normalizePath(dirname(skill.path))));
+}

--- a/packages/happy-cli/src/utils/createSessionMetadata.ts
+++ b/packages/happy-cli/src/utils/createSessionMetadata.ts
@@ -32,6 +32,8 @@ export interface CreateSessionMetadataOptions {
     machineId: string;
     /** How the session was started */
     startedBy?: 'daemon' | 'terminal';
+    /** Discovered skills metadata (used by Codex) */
+    skills?: Metadata['skills'];
 }
 
 /**
@@ -158,6 +160,7 @@ export function createSessionMetadata(opts: CreateSessionMetadataOptions): Sessi
         lifecycleState: 'running',
         lifecycleStateSince: Date.now(),
         flavor: opts.flavor,
+        ...(opts.skills ? { skills: opts.skills } : {}),
         // Worktree metadata: env vars from daemon take priority, otherwise detect via git
         ...detectWorktreeMetadata(),
     };


### PR DESCRIPTION
## Summary

为 Codex 会话添加 `$` 前缀技能（skill）自动补全支持。用户在 Codex 会话中输入 `$` 可触发已安装的技能搜索，选择后插入对应的技能名称。

## Changes

- **happy-app**: 新增 `SkillSuggestion` 组件，展示技能名称、描述、作用域标签（REPO/USER/SYSTEM）
- **happy-app**: 新增 `suggestionSkills.ts`，从 session metadata 读取技能列表并支持 Fuse.js 模糊搜索
- **happy-app**: `autocompletePrefixes` 在 Codex 会话中增加 `$` 前缀
- **happy-app**: 添加 10 语言 i18n 翻译键 `skillScopeRepo` / `skillScopePersonal` / `skillScopeSystem`
- **happy-cli**: 新增 `skillDiscovery.ts`，启动时扫描 Git 仓库（`.agents/skills`、`.codex/skills`）、用户目录（`~/.agents/skills`、`~/.codex/skills`）、系统目录（`/etc/codex/skills`）中的技能
- **happy-cli**: 每 30 秒轮询重新扫描技能目录，变更时自动更新 session metadata
- **happy-cli**: 解析 `codex/config.toml` 过滤禁用的技能

## Testing

- [x] 本地测试通过
- [x] TypeScript 类型检查通过 (happy-cli)
- [x] 现有测试通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)