### PR TITLE
fix(app): remove hardcoded limit on slash command and file autocomplete

### DIFF
--- a/packages/happy-app/sources/components/autocomplete/suggestions.ts
+++ b/packages/happy-app/sources/components/autocomplete/suggestions.ts
@@ -13,7 +13,7 @@ export async function getCommandSuggestions(sessionId: string, query: string): P
     
     try {
         // Use the command search cache with fuzzy matching
-        const commands = await searchCommands(sessionId, searchTerm, { limit: 5 });
+        const commands = await searchCommands(sessionId, searchTerm);
         
         // Convert CommandItem to suggestion format
         return commands.map((cmd: CommandItem) => ({
@@ -41,7 +41,7 @@ export async function getFileMentionSuggestions(sessionId: string, query: string
     
     try {
         // Use the file search cache with fuzzy matching
-        const files = await searchFiles(sessionId, searchTerm, { limit: 5 });
+        const files = await searchFiles(sessionId, searchTerm);
         
         // Convert FileItem to suggestion format
         return files.map((file: FileItem) => ({

--- a/packages/happy-app/sources/sync/suggestionCommands.ts
+++ b/packages/happy-app/sources/sync/suggestionCommands.ts
@@ -131,17 +131,13 @@ export async function searchCommands(
     query: string,
     options: SearchOptions = {}
 ): Promise<CommandItem[]> {
-    const { limit = 10, threshold = 0.3 } = options;
-    
-    // Get commands from session metadata (no caching)
+    const { limit, threshold = 0.3 } = options;
     const commands = getCommandsFromSession(sessionId);
-    
-    // If query is empty, return all commands
+
     if (!query || query.trim().length === 0) {
-        return commands.slice(0, limit);
+        return limit ? commands.slice(0, limit) : commands;
     }
-    
-    // Setup Fuse for fuzzy search
+
     const fuseOptions = {
         keys: [
             { name: 'command', weight: 0.7 },
@@ -154,10 +150,12 @@ export async function searchCommands(
         ignoreLocation: true,
         useExtendedSearch: true
     };
-    
+
     const fuse = new Fuse(commands, fuseOptions);
-    const results = fuse.search(query, { limit });
-    
+    const results = limit
+        ? fuse.search(query, { limit })
+        : fuse.search(query);
+
     return results.map(result => result.item);
 }
 

--- a/packages/happy-app/sources/sync/suggestionFile.ts
+++ b/packages/happy-app/sources/sync/suggestionFile.ts
@@ -162,20 +162,15 @@ class FileSearchCache {
             return [];
         }
 
-        const { limit = 10, threshold = 0.3 } = options;
+        const { limit, threshold = 0.3 } = options;
 
-        // If query is empty, return most recently modified files
         if (!query || query.trim().length === 0) {
-            return cache.files.slice(0, limit);
+            return limit ? cache.files.slice(0, limit) : [...cache.files];
         }
 
-        // Perform fuzzy search
-        const searchOptions = {
-            limit,
-            threshold
-        };
-
-        const results = cache.fuse.search(query, searchOptions);
+        const results = limit
+            ? cache.fuse.search(query, { limit })
+            : cache.fuse.search(query);
         return results.map(result => result.item);
     }
 
@@ -200,7 +195,7 @@ export const fileSearchCache = new FileSearchCache();
 export async function searchFiles(
     sessionId: string,
     query: string,
-    options: SearchOptions = {}
+    options: SearchOptions = {},
 ): Promise<FileItem[]> {
     return fileSearchCache.search(sessionId, query, options);
 }


### PR DESCRIPTION
## Summary

移除 slash command 和文件自动补全搜索中硬编码的 `limit` 参数，改为由调用方按需传入，默认返回全部匹配结果。

## Changes

- `suggestions.ts`：调用 `searchCommands` / `searchFiles` 时不再传入 `{ limit: 5 }`
- `suggestionCommands.ts`：`searchCommands` 的 `limit` 改为可选，为空时不截断结果
- `suggestionFile.ts`：`searchFiles` 的 `limit` 改为可选，为空时不截断结果

## Testing

- [x] Tested locally
- [x] Existing tests pass
- [ ] New tests added (if applicable)

## Related issues

N/A