### PR TITLE
fix: paginate public shared session messages (stop ~150-message truncation)

### DIFF
--- a/packages/happy-app/sources/app/(app)/share/[token].tsx
+++ b/packages/happy-app/sources/app/(app)/share/[token].tsx
@@ -35,7 +35,7 @@ function OwnerCard({ owner, floating }: { owner: { username: string | null; firs
 export default memo(function PublicShareScreen() {
     const { token } = useLocalSearchParams<{ token: string }>();
     const { theme } = useUnistyles();
-    const { state, messages, metadata, owner, sessionId, giveConsent } = usePublicShareSession(token);
+    const { state, messages, metadata, owner, sessionId, hasMore, isLoadingMore, loadMore, giveConsent } = usePublicShareSession(token);
 
     const keyExtractor = useCallback((item: Message) => item.id, []);
     const renderItem = useCallback(({ item }: { item: Message }) => (
@@ -46,6 +46,25 @@ export default memo(function PublicShareScreen() {
             readOnly
         />
     ), [metadata, sessionId]);
+
+    // Inverted list: reaching the "end" means scrolling to the top (oldest message).
+    const onEndReached = useCallback(() => {
+        if (hasMore) {
+            loadMore();
+        }
+    }, [hasMore, loadMore]);
+
+    // Rendered at the visual top of the inverted list while older messages are loading.
+    const listFooter = useCallback(() => {
+        if (!isLoadingMore) {
+            return null;
+        }
+        return (
+            <View style={styles.loadingMore}>
+                <ActivityIndicator size="small" color={theme.colors.textSecondary} />
+            </View>
+        );
+    }, [isLoadingMore, theme.colors.textSecondary]);
 
     // Loading
     if (state === 'loading') {
@@ -121,7 +140,18 @@ export default memo(function PublicShareScreen() {
                     keyExtractor={keyExtractor}
                     renderItem={renderItem}
                     inverted
+                    // flex:1 bounds the list as its own scroll container below the OwnerCard
+                    // sibling, matching ChatList.
+                    style={styles.list}
                     contentContainerStyle={styles.listContent}
+                    // Keep the viewport anchored when older messages are prepended at the top.
+                    maintainVisibleContentPosition={{
+                        minIndexForVisible: 0,
+                        autoscrollToTopThreshold: 100,
+                    }}
+                    onEndReached={onEndReached}
+                    onEndReachedThreshold={0.5}
+                    ListFooterComponent={listFooter}
                 />
             )}
         </View>
@@ -188,7 +218,15 @@ const styles = StyleSheet.create((theme) => ({
         ...Typography.default('semiBold'),
         fontSize: 17,
     },
+    list: {
+        flex: 1,
+    },
     listContent: {
         paddingVertical: 8,
+    },
+    loadingMore: {
+        paddingVertical: 16,
+        alignItems: 'center',
+        justifyContent: 'center',
     },
 }));

--- a/packages/happy-app/sources/hooks/usePublicShareSession.ts
+++ b/packages/happy-app/sources/hooks/usePublicShareSession.ts
@@ -1,9 +1,9 @@
 import { useState, useCallback, useEffect, useRef } from 'react';
-import { accessPublicShare, getPublicShareMessages } from '@/sync/apiSharing';
+import { accessPublicShare, getPublicShareMessages, PublicShareMessage } from '@/sync/apiSharing';
 import { decryptDataKeyFromPublicShare } from '@/sync/encryption/publicShareEncryption';
 import { AES256Encryption } from '@/sync/encryption/encryptor';
 import { decodeBase64 } from '@/encryption/base64';
-import { normalizeRawMessage } from '@/sync/typesRaw';
+import { normalizeRawMessage, NormalizedMessage } from '@/sync/typesRaw';
 import { createReducer, reducer } from '@/sync/reducer/reducer';
 import { getServerUrl } from '@/sync/serverConfig';
 import { PublicShareNotFoundError, ConsentRequiredError, ShareUserProfile } from '@/sync/sharingTypes';
@@ -12,17 +12,80 @@ import { Metadata, MetadataSchema } from '@/sync/storageTypes';
 
 export type PublicShareState = 'loading' | 'loaded' | 'error' | 'consent-required' | 'not-found';
 
+// Page size for the public share viewer. The server returns the newest page first, then we
+// page backwards through older messages with `before_seq` as the user scrolls up.
+const PAGE_SIZE = 100;
+
+/**
+ * Read-only public share session viewer with cursor pagination.
+ *
+ * Unlike normal sessions (which run through the full Sync engine: sockets, storage, incremental
+ * sync, persisted cursors, auth), a public share is anonymous and read-only, so this hook keeps
+ * its own lightweight pagination state:
+ *  - `decryptorRef` holds the AES key derived from the share token so `loadMore` can decrypt
+ *    additional pages without re-deriving it.
+ *  - `rawMessagesRef` accumulates every decrypted+normalized message (oldest-first). Each page is
+ *    prepended, then the reducer is re-run over the whole set — re-reducing is required because
+ *    tool calls / sidechains can span page boundaries, and it keeps the merge logic identical to
+ *    the single-shot path.
+ *  - `oldestSeqRef` is the cursor for the next older page; `hasMore` reports whether one exists.
+ */
 export function usePublicShareSession(token: string) {
     const [state, setState] = useState<PublicShareState>('loading');
     const [messages, setMessages] = useState<Message[]>([]);
     const [metadata, setMetadata] = useState<Metadata | null>(null);
     const [owner, setOwner] = useState<ShareUserProfile | null>(null);
     const [sessionId, setSessionId] = useState<string | null>(null);
+    const [hasMore, setHasMore] = useState(false);
+    const [isLoadingMore, setIsLoadingMore] = useState(false);
+
     const consentRef = useRef(false);
+    const decryptorRef = useRef<AES256Encryption | null>(null);
+    const rawMessagesRef = useRef<NormalizedMessage[]>([]);
+    const oldestSeqRef = useRef<number | null>(null);
+    const loadingMoreRef = useRef(false);
+
+    // Decrypt a page of encrypted messages (server returns newest-first) into normalized messages
+    // ordered oldest-first, and report the smallest seq in the page (the next pagination cursor).
+    const processPage = useCallback(async (
+        decryptor: AES256Encryption,
+        encryptedMessages: PublicShareMessage[],
+    ): Promise<{ normalized: NormalizedMessage[]; minSeq: number | null }> => {
+        if (encryptedMessages.length === 0) {
+            return { normalized: [], minSeq: null };
+        }
+        // Reverse to oldest-first so the reducer processes messages chronologically.
+        const reversed = [...encryptedMessages].reverse();
+        const encryptedBytes = reversed.map(m => decodeBase64(m.content.c, 'base64'));
+        const decryptedContents = await decryptor.decrypt(encryptedBytes);
+        const normalized = reversed
+            .map((m, i) => {
+                const content = decryptedContents[i];
+                if (!content) return null;
+                return normalizeRawMessage(m.id, m.localId, m.createdAt, content);
+            })
+            .filter((m): m is NonNullable<typeof m> => m !== null);
+        const minSeq = Math.min(...encryptedMessages.map(m => m.seq));
+        return { normalized, minSeq };
+    }, []);
+
+    // Re-run the reducer over all accumulated normalized messages and publish them newest-first.
+    const publishMessages = useCallback(() => {
+        const result = reducer(createReducer(), rawMessagesRef.current);
+        // Sort by createdAt since the reducer processes event messages (e.g. title changes) before
+        // regular messages, breaking chronological order.
+        result.messages.sort((a, b) => b.createdAt - a.createdAt);
+        setMessages(result.messages);
+    }, []);
 
     const load = useCallback(async (withConsent: boolean) => {
         try {
             setState('loading');
+            // Reset pagination accumulators on every (re)load.
+            rawMessagesRef.current = [];
+            oldestSeqRef.current = null;
+            setHasMore(false);
+
             const serverUrl = getServerUrl();
             const consent = withConsent || undefined;
 
@@ -39,6 +102,7 @@ export function usePublicShareSession(token: string) {
             }
 
             const decryptor = new AES256Encryption(dataKey);
+            decryptorRef.current = decryptor;
 
             // 3. Decrypt metadata
             if (shareData.session.metadata) {
@@ -56,35 +120,18 @@ export function usePublicShareSession(token: string) {
                 }
             }
 
-            // 4. Fetch encrypted messages
-            const encryptedMessages = await getPublicShareMessages(serverUrl, token, consent);
+            // 4. Fetch the newest page of encrypted messages
+            const { messages: encryptedMessages, hasMore: more } = await getPublicShareMessages(serverUrl, token, {
+                consent,
+                limit: PAGE_SIZE,
+            });
 
-            if (encryptedMessages.length === 0) {
-                setMessages([]);
-                setState('loaded');
-                return;
-            }
-
-            // 5. Decrypt messages (reverse to get oldest first)
-            const reversed = [...encryptedMessages].reverse();
-            const encryptedBytes = reversed.map(m => decodeBase64(m.content.c, 'base64'));
-            const decryptedContents = await decryptor.decrypt(encryptedBytes);
-
-            // 6. Normalize messages
-            const normalizedMessages = reversed
-                .map((m, i) => {
-                    const content = decryptedContents[i];
-                    if (!content) return null;
-                    return normalizeRawMessage(m.id, m.localId, m.createdAt, content);
-                })
-                .filter((m): m is NonNullable<typeof m> => m !== null);
-
-            // 7. Reduce to Message[]
-            const result = reducer(createReducer(), normalizedMessages);
-            // Sort by createdAt since the reducer processes event messages
-            // (e.g. title changes) before regular messages, breaking chronological order
-            result.messages.sort((a, b) => b.createdAt - a.createdAt);
-            setMessages(result.messages);
+            // 5. Decrypt + normalize + reduce
+            const { normalized, minSeq } = await processPage(decryptor, encryptedMessages);
+            rawMessagesRef.current = normalized;
+            oldestSeqRef.current = minSeq;
+            setHasMore(more);
+            publishMessages();
             setState('loaded');
         } catch (e) {
             if (e instanceof PublicShareNotFoundError) {
@@ -96,7 +143,43 @@ export function usePublicShareSession(token: string) {
                 setState('error');
             }
         }
-    }, [token]);
+    }, [token, processPage, publishMessages]);
+
+    // Load the next older page. Triggered when the inverted list reaches its end (scrolled to top).
+    const loadMore = useCallback(async () => {
+        if (loadingMoreRef.current) return;
+        const decryptor = decryptorRef.current;
+        const before = oldestSeqRef.current;
+        if (!decryptor || before === null) return;
+
+        loadingMoreRef.current = true;
+        setIsLoadingMore(true);
+        try {
+            const serverUrl = getServerUrl();
+            const consent = consentRef.current || undefined;
+            const { messages: encryptedMessages, hasMore: more } = await getPublicShareMessages(serverUrl, token, {
+                consent,
+                beforeSeq: before,
+                limit: PAGE_SIZE,
+            });
+
+            const { normalized, minSeq } = await processPage(decryptor, encryptedMessages);
+            if (normalized.length > 0) {
+                // Older messages go in front of the accumulator (which is oldest-first).
+                rawMessagesRef.current = [...normalized, ...rawMessagesRef.current];
+            }
+            if (minSeq !== null) {
+                oldestSeqRef.current = minSeq;
+            }
+            setHasMore(more);
+            publishMessages();
+        } catch {
+            // Never surface loading errors — the user can retry by scrolling again.
+        } finally {
+            loadingMoreRef.current = false;
+            setIsLoadingMore(false);
+        }
+    }, [token, processPage, publishMessages]);
 
     useEffect(() => {
         load(false);
@@ -109,5 +192,5 @@ export function usePublicShareSession(token: string) {
         }
     }, [load]);
 
-    return { state, messages, metadata, owner, sessionId, giveConsent };
+    return { state, messages, metadata, owner, sessionId, hasMore, isLoadingMore, loadMore, giveConsent };
 }

--- a/packages/happy-app/sources/sync/apiSharing.ts
+++ b/packages/happy-app/sources/sync/apiSharing.ts
@@ -323,17 +323,36 @@ export async function deletePublicShare(
     }
 }
 
+export interface PublicShareMessage {
+    id: string;
+    seq: number;
+    content: { t: string; c: string };
+    localId: string | null;
+    createdAt: number;
+    updatedAt: number;
+}
+
 /**
- * Fetch messages from a public share (public endpoint, no auth required)
+ * Fetch a page of messages from a public share (public endpoint, no auth required).
+ *
+ * Pagination mirrors the authenticated v3 messages route: messages come back newest-first,
+ * `beforeSeq` loads the page of older messages preceding that seq, and `hasMore` indicates
+ * whether older messages still exist.
  */
 export async function getPublicShareMessages(
     serverUrl: string,
     token: string,
-    consent?: boolean
-): Promise<{ id: string; seq: number; content: { t: string; c: string }; localId: string | null; createdAt: number; updatedAt: number }[]> {
+    opts?: { consent?: boolean; beforeSeq?: number; limit?: number }
+): Promise<{ messages: PublicShareMessage[]; hasMore: boolean }> {
     const url = new URL(`${serverUrl}/v1/public-share/${token}/messages`);
-    if (consent) {
+    if (opts?.consent) {
         url.searchParams.set('consent', 'true');
+    }
+    if (opts?.beforeSeq !== undefined) {
+        url.searchParams.set('before_seq', String(opts.beforeSeq));
+    }
+    if (opts?.limit !== undefined) {
+        url.searchParams.set('limit', String(opts.limit));
     }
 
     const response = await fetch(url.toString(), {
@@ -354,7 +373,7 @@ export async function getPublicShareMessages(
     }
 
     const data = await response.json();
-    return data.messages;
+    return { messages: data.messages as PublicShareMessage[], hasMore: data.hasMore ?? false };
 }
 
 /**

--- a/packages/happy-server/sources/app/api/routes/publicShareRoutes.ts
+++ b/packages/happy-server/sources/app/api/routes/publicShareRoutes.ts
@@ -426,12 +426,14 @@ export function publicShareRoutes(app: Fastify) {
                 token: z.string()
             }),
             querystring: z.object({
-                consent: z.coerce.boolean().optional()
-            }).optional()
+                consent: z.coerce.boolean().optional(),
+                before_seq: z.coerce.number().int().min(1).optional(),
+                limit: z.coerce.number().int().min(1).max(150).default(100)
+            })
         }
     }, async (request, reply) => {
         const { token } = request.params;
-        const { consent } = request.query || {};
+        const { consent, before_seq, limit } = request.query;
         const tokenHash = createHash('sha256').update(token, 'utf8').digest();
 
         // Try to get user ID if authenticated
@@ -499,10 +501,15 @@ export function publicShareRoutes(app: Fastify) {
             });
         }
 
+        // Paginate by seq cursor (newest-first), mirroring the authenticated v3 messages route.
+        // before_seq loads older messages; limit+1 lets us report hasMore without a second query.
         const messages = await db.sessionMessage.findMany({
-            where: { sessionId: publicShare.sessionId },
-            orderBy: { createdAt: 'desc' },
-            take: 150,
+            where: {
+                sessionId: publicShare.sessionId,
+                ...(before_seq !== undefined ? { seq: { lt: before_seq } } : {})
+            },
+            orderBy: { seq: 'desc' },
+            take: limit + 1,
             select: {
                 id: true,
                 seq: true,
@@ -513,15 +520,19 @@ export function publicShareRoutes(app: Fastify) {
             }
         });
 
+        const hasMore = messages.length > limit;
+        const page = hasMore ? messages.slice(0, limit) : messages;
+
         return reply.send({
-            messages: messages.map((v) => ({
+            messages: page.map((v) => ({
                 id: v.id,
                 seq: v.seq,
                 content: v.content,
                 localId: v.localId,
                 createdAt: v.createdAt.getTime(),
                 updatedAt: v.updatedAt.getTime()
-            }))
+            })),
+            hasMore
         });
     });
 


### PR DESCRIPTION
## Summary

Public shared sessions silently truncated to the latest ~150 messages. The public-share messages endpoint (`GET /v1/public-share/:token/messages`) was hardcoded to `take: 150` with no pagination and no `hasMore`, so any shared session with more than ~150 messages dropped its older history with no way to load it. This PR adds cursor pagination end-to-end, mirroring the authenticated v3 messages route.

## Changes

- **server** (`publicShareRoutes.ts`): the messages endpoint now accepts `before_seq` and `limit` query params (default 100, max 150), orders by the `seq` cursor, and uses `take: limit + 1` to return a `hasMore` flag (previously: hardcoded `take: 150`, no `hasMore`). Backed by the existing `SessionMessage @@index([sessionId, seq])`, so paging stays `O(limit)`.
- **client api** (`apiSharing.ts`): `getPublicShareMessages` now takes `{ consent, beforeSeq, limit }` and returns `{ messages, hasMore }`.
- **hook** (`usePublicShareSession.ts`): caches the token-derived decryptor, accumulates normalized messages across pages (re-running the reducer per page so tool-call/sidechain merging stays correct across page boundaries), and exposes `loadMore` / `hasMore` / `isLoadingMore`.
- **ui** (`share/[token].tsx`): the inverted `FlatList` triggers `loadMore` on `onEndReached` with a top loading spinner and `maintainVisibleContentPosition`; the list is given `flex:1` so it owns the scroll container (matching `ChatList`).

## Testing

How was this tested?

- [x] Tested locally — ran happy-server against a local Postgres/Redis/MinIO, created a real shared session with 586 messages; verified page 1 returns 100 + `hasMore=true`, subsequent `before_seq` pages return correct non-overlapping ranges, and the share page loads older messages on scroll-to-top in the browser.
- [x] Existing tests pass — `yarn build` (`tsc --noEmit`) passes for happy-server; happy-app typecheck shows no new errors from the changed files.
- [ ] New tests added (if applicable) — no automated test harness exists for this endpoint; verified via a seeded integration check + browser e2e.

## Related issues

N/A
