### PR TITLE
fix(cli): clean up terminal stdin on remote→local mode switch

### DIFF
--- a/packages/happy-cli/scripts/claude_version_utils.cjs
+++ b/packages/happy-cli/scripts/claude_version_utils.cjs
@@ -498,8 +498,42 @@ function runClaudeCli(cliPath) {
             env: process.env,
             shell: process.platform === 'win32'
         });
-        child.on('exit', (code) => {
-            process.exit(code || 0);
+
+        const exitCodeForSignal = (s) => s === 'SIGTERM' ? 143 : s === 'SIGINT' ? 130 : 1;
+        const childAlive = () => child.exitCode === null && child.signalCode === null;
+
+        let exiting = false;
+        const forwardSignal = (signal) => {
+            if (exiting) return;
+            exiting = true;
+
+            try {
+                if (childAlive()) {
+                    child.kill(signal);
+                }
+            } catch (e) {
+                // Ignore forwarding failures; the child may already be gone.
+            }
+
+            // If the child does not exit promptly, force it down so an orphaned
+            // Claude process cannot keep sharing the same interactive TTY after
+            // Happy switches from local mode to remote mode.
+            setTimeout(() => {
+                try {
+                    if (childAlive()) {
+                        child.kill('SIGKILL');
+                    }
+                } catch (e) {}
+                process.exit(exitCodeForSignal(signal));
+            }, 2000).unref();
+        };
+
+        for (const sig of ['SIGTERM', 'SIGINT', 'SIGHUP']) {
+            process.once(sig, () => forwardSignal(sig));
+        }
+
+        child.on('exit', (code, signal) => {
+            process.exit(signal ? exitCodeForSignal(signal) : (code || 0));
         });
     }
 }

--- a/packages/happy-cli/src/claude/claudeLocal.ts
+++ b/packages/happy-cli/src/claude/claudeLocal.ts
@@ -178,6 +178,25 @@ export async function claudeLocal(opts: {
     try {
         // Start the interactive process
         process.stdin.pause();
+
+        // Force blocking I/O on the inherited stdin fd before spawning the child.
+        // Node leaves O_NONBLOCK set on the fd after libuv-mode reads (Ink in
+        // remote mode and our drain helper both read this way). When claude code
+        // inherits the same fd via stdio: 'inherit' and reads in blocking mode,
+        // the kernel returns EAGAIN instead of bytes — the visible symptom is
+        // duplicated cursors, garbled echo, and mis-placed CJK/IME composition
+        // cursors right after a remote→local switch. setBlocking(true) clears
+        // O_NONBLOCK before spawn dups the fd into the child.
+        const stdinHandle = (process.stdin as any)._handle;
+        if (stdinHandle && typeof stdinHandle.setBlocking === 'function') {
+            try {
+                stdinHandle.setBlocking(true);
+                logger.debug('[ClaudeLocal] forced stdin to blocking mode before spawn');
+            } catch (err) {
+                logger.debug('[ClaudeLocal] setBlocking(true) failed: ' + String(err));
+            }
+        }
+
         await new Promise<void>((r, reject) => {
             const args: string[] = []
 

--- a/packages/happy-cli/src/claude/claudeRemoteLauncher.ts
+++ b/packages/happy-cli/src/claude/claudeRemoteLauncher.ts
@@ -6,6 +6,7 @@ import React from "react";
 import { claudeRemote } from "./claudeRemote";
 import { PermissionHandler } from "./utils/permissionHandler";
 import { Future } from "@/utils/future";
+import { cleanupStdinAfterInk } from "@/utils/terminalStdinCleanup";
 import { Query, SDKAssistantMessage, SDKMessage, SDKResultMessage, SDKSystemMessage, SDKUserMessage } from "./sdk";
 import { formatClaudeMessageForInk } from "@/ui/messageFormatterInk";
 import { isDebug } from "@/utils/env";
@@ -61,14 +62,6 @@ export async function claudeRemoteLauncher(session: Session): Promise<'switch' |
             exitOnCtrlC: false,
             patchConsole: false
         });
-    }
-
-    if (hasTTY) {
-        process.stdin.resume();
-        if (process.stdin.isTTY) {
-            process.stdin.setRawMode(true);
-        }
-        process.stdin.setEncoding("utf8");
     }
 
     // Handle abort
@@ -668,14 +661,24 @@ export async function claudeRemoteLauncher(session: Session): Promise<'switch' |
         // Clean up permission handler
         permissionHandler.reset();
 
-        // Reset Terminal
-        process.stdin.off('data', abort);
-        if (process.stdin.isTTY) {
-            process.stdin.setRawMode(false);
-        }
+        // Reset Terminal — hand stdin cleanly back to the next consumer.
+        // Unmount Ink FIRST: it restores its own stdin state (raw mode, key
+        // listeners) during teardown, so that must run before we touch stdin.
         if (inkInstance) {
             inkInstance.unmount();
         }
+        // Drain keystrokes buffered while Ink owned stdin (the extra spaces from
+        // the double-space switch, or anything typed during the switch delay) so
+        // they don't leak into the next interactive child via stdio: 'inherit'.
+        // Raw mode is kept on through the drain only when we hand off to local
+        // mode (claude re-asserts raw itself, avoiding a cooked-echo race); on a
+        // full exit we restore cooked mode so the user's shell stays usable.
+        await cleanupStdinAfterInk({
+            stdin: process.stdin,
+            drainMs: 150,
+            leaveRawMode: exitReason === 'switch',
+            onDebug: ({ bytes, chunks }) => logger.debug(`[remote] drained ${bytes}B / ${chunks} chunk(s) from stdin before handoff`),
+        });
         messageBuffer.clear();
         session.queue.setOnMessage(null);
 

--- a/packages/happy-cli/src/claude/runClaude.ts
+++ b/packages/happy-cli/src/claude/runClaude.ts
@@ -29,6 +29,7 @@ import { resolve, join } from 'node:path';
 import { detectGitWorktree } from '@/utils/gitWorktree';
 import { startOfflineReconnection, connectionState } from '@/utils/serverConnectionErrors';
 import { claudeLocal } from '@/claude/claudeLocal';
+import { cleanupStdinAfterInk } from '@/utils/terminalStdinCleanup';
 import { createSessionScanner } from '@/claude/utils/sessionScanner';
 import { Session } from './session';
 import { findClaudeProjectId } from '@/claude/utils/claudeSessionIndex';
@@ -556,6 +557,12 @@ export async function runClaude(credentials: Credentials, options: StartOptions 
     // Setup signal handlers for graceful shutdown
     const cleanup = async () => {
         logger.debug('[START] Received termination signal, cleaning up...');
+
+        // Restore the terminal to cooked mode BEFORE any async work or
+        // process.exit(): signal handlers bypass the remote launcher's finally
+        // block, so without this the shell is left stuck in raw mode (the
+        // classic "had to run reset" symptom) when killed during remote mode.
+        await cleanupStdinAfterInk({ stdin: process.stdin, drainMs: 0, leaveRawMode: false });
 
         try {
             // Update lifecycle state to archived before closing

--- a/packages/happy-cli/src/utils/terminalStdinCleanup.test.ts
+++ b/packages/happy-cli/src/utils/terminalStdinCleanup.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi } from 'vitest';
+import { cleanupStdinAfterInk } from './terminalStdinCleanup';
+
+function makeFakeStdin(opts: { isTTY: boolean }) {
+    const dataListeners = new Set<(chunk: unknown) => void>();
+    const calls: string[] = [];
+    const stdin = {
+        isTTY: opts.isTTY,
+        rawMode: false as boolean,
+        on(event: 'data', listener: (chunk: unknown) => void) {
+            if (event === 'data') dataListeners.add(listener);
+            return stdin;
+        },
+        off(event: 'data', listener: (chunk: unknown) => void) {
+            if (event === 'data') dataListeners.delete(listener);
+            return stdin;
+        },
+        resume() { calls.push('resume'); },
+        pause() { calls.push('pause'); },
+        setRawMode(value: boolean) { stdin.rawMode = value; calls.push(`setRawMode:${value}`); },
+        // test helper to simulate bytes arriving during the drain window
+        emit(chunk: unknown) { for (const l of dataListeners) l(chunk); },
+        dataListenerCount() { return dataListeners.size; },
+    };
+    return { stdin, calls };
+}
+
+describe('cleanupStdinAfterInk', () => {
+    it('is a no-op when stdin is not a TTY', async () => {
+        const { stdin, calls } = makeFakeStdin({ isTTY: false });
+        await cleanupStdinAfterInk({ stdin, drainMs: 50 });
+        expect(calls).toEqual([]);
+    });
+
+    it('exit path (drainMs:0, leaveRawMode:false) restores cooked mode without draining', async () => {
+        const { stdin, calls } = makeFakeStdin({ isTTY: true });
+        await cleanupStdinAfterInk({ stdin, drainMs: 0, leaveRawMode: false });
+        // No drain: never resumes stdin or asserts raw on; just pause + cooked.
+        expect(calls).toEqual(['pause', 'setRawMode:false']);
+        expect(stdin.rawMode).toBe(false);
+        expect(stdin.dataListenerCount()).toBe(0);
+    });
+
+    it('switch path drains buffered keystrokes and keeps raw mode on for the handoff', async () => {
+        vi.useFakeTimers();
+        try {
+            const { stdin, calls } = makeFakeStdin({ isTTY: true });
+            const onDebug = vi.fn();
+            const done = cleanupStdinAfterInk({ stdin, drainMs: 150, leaveRawMode: true, onDebug });
+
+            // Bytes that arrive during the drain window are swallowed, not leaked.
+            stdin.emit('  ');                              // 2 bytes (string)
+            stdin.emit(Buffer.from([0x1b, 0x5b, 0x41]));   // 3 bytes (buffer)
+
+            await vi.advanceTimersByTimeAsync(150);
+            await done;
+
+            expect(onDebug).toHaveBeenCalledWith({ bytes: 5, chunks: 2 });
+            expect(calls).toContain('setRawMode:true');    // re-asserted for the drain
+            expect(calls).toContain('resume');
+            expect(calls).toContain('pause');
+            expect(calls).not.toContain('setRawMode:false');
+            expect(stdin.rawMode).toBe(true);
+            expect(stdin.dataListenerCount()).toBe(0);     // listener detached
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
+    it('drain + leaveRawMode:false restores cooked mode after draining', async () => {
+        vi.useFakeTimers();
+        try {
+            const { stdin } = makeFakeStdin({ isTTY: true });
+            const done = cleanupStdinAfterInk({ stdin, drainMs: 150, leaveRawMode: false });
+            await vi.advanceTimersByTimeAsync(150);
+            await done;
+            expect(stdin.rawMode).toBe(false);
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+});

--- a/packages/happy-cli/src/utils/terminalStdinCleanup.ts
+++ b/packages/happy-cli/src/utils/terminalStdinCleanup.ts
@@ -1,0 +1,109 @@
+/**
+ * Helpers used to safely hand stdin back from an Ink-driven UI (e.g. the
+ * remote-mode display) to the next interactive child process (e.g. local
+ * `claude` running with stdio: 'inherit').
+ *
+ * Two failure modes we are guarding against on the remote→local switch:
+ *
+ *  1. Bytes that landed in stdin's read buffer while Ink owned it (extra
+ *     spaces from the double-space confirmation, or anything typed during
+ *     the brief "Switching to local mode…" delay) are still pending after
+ *     Ink unmounts. The next process inherits the same fd and consumes
+ *     them as if the user had typed them at the new prompt.
+ *
+ *  2. Once Ink calls setRawMode(false) on its componentWillUnmount, the
+ *     terminal driver returns to cooked mode. Any keystroke that lands
+ *     between Ink unmount and the child setting raw mode is *echoed by
+ *     the kernel* at whatever screen position Ink last left the cursor —
+ *     producing visible garbage (and what looks like a "second cursor")
+ *     on top of the next process's UI.
+ *
+ * The cleanup keeps the terminal in raw mode for the whole drain window,
+ * silently consumes any pending bytes, then pauses stdin. When handing off
+ * to another raw-mode consumer (claude code) we leave raw mode enabled so
+ * there is no cooked-mode race window; when the process is exiting instead
+ * we restore cooked mode via leaveRawMode: false so the user's shell stays
+ * usable. Passing drainMs: 0 skips the drain entirely (the exit path).
+ *
+ * NOTE: this only normalises stdin state. The other half of a clean handoff
+ * lives in claudeLocal, which forces the inherited fd back into blocking I/O
+ * (setBlocking) before spawning the child — without it the child can read
+ * partial/empty bytes (EAGAIN), which is what corrupts CJK/IME cursors.
+ */
+
+/** Run a best-effort stdin operation; failures here are benign (stdin may be paused/destroyed). */
+function safe(fn: () => void): void {
+    try {
+        fn();
+    } catch {
+        // ignore
+    }
+}
+
+export async function cleanupStdinAfterInk(opts: {
+    stdin: {
+        isTTY?: boolean;
+        on: (event: 'data', listener: (chunk: unknown) => void) => unknown;
+        off: (event: 'data', listener: (chunk: unknown) => void) => unknown;
+        resume: () => void;
+        pause: () => void;
+        setRawMode?: (value: boolean) => void;
+    };
+    /**
+     * Drain buffered input for this many ms. The terminal stays in raw mode
+     * for this window so the kernel does not echo any keystrokes that arrive.
+     * Pass 0 to skip the drain entirely (e.g. on the exit path).
+     */
+    drainMs?: number;
+    /**
+     * If true (default), leave the terminal in raw mode after the drain.
+     * The caller should immediately hand stdin to a process that itself
+     * uses raw mode (e.g. claude code via stdio: 'inherit'). When false,
+     * raw mode is restored to cooked at the end — use only when no raw-mode
+     * consumer follows (e.g. the process is about to exit to the shell).
+     */
+    leaveRawMode?: boolean;
+    /**
+     * Optional debug sink so callers can log how much was drained.
+     */
+    onDebug?: (event: { bytes: number; chunks: number }) => void;
+}): Promise<void> {
+    const stdin = opts.stdin;
+    if (!stdin.isTTY) return;
+
+    const leaveRawMode = opts.leaveRawMode ?? true;
+    const drainMs = Math.max(0, opts.drainMs ?? 0);
+
+    let bytes = 0;
+    let chunks = 0;
+
+    if (drainMs > 0) {
+        // Re-assert raw mode for the drain window. Ink's unmount turns it off
+        // before we get here, so without this the kernel echoes pending or
+        // arriving keystrokes to the screen.
+        safe(() => stdin.setRawMode?.(true));
+
+        const drainListener = (chunk: unknown) => {
+            chunks++;
+            if (typeof chunk === 'string') {
+                bytes += Buffer.byteLength(chunk);
+            } else if (chunk && typeof (chunk as Buffer).length === 'number') {
+                bytes += (chunk as Buffer).length;
+            }
+        };
+
+        try {
+            stdin.on('data', drainListener);
+            stdin.resume();
+            await new Promise<void>((resolve) => setTimeout(resolve, drainMs));
+        } finally {
+            safe(() => stdin.off('data', drainListener));
+        }
+    }
+
+    safe(() => stdin.pause());
+    if (!leaveRawMode) {
+        safe(() => stdin.setRawMode?.(false));
+    }
+    opts.onDebug?.({ bytes, chunks });
+}


### PR DESCRIPTION
## Summary

Fixes terminal/stdin corruption when switching from remote (Ink) mode back to
local Claude — most visibly mis-placed CJK/IME composition cursors, plus
duplicated cursors and garbled echo. Aligns with the approach shipped upstream
in slopus/happy v1.1.10 (rather than the unmerged PR slopus/happy#570/#647).

## Root cause

Several issues compound during the remote→local handoff:

1. **O_NONBLOCK left on the stdin fd** after libuv-mode reads (Ink in remote
   mode reads this way). When Claude inherits the fd via `stdio: 'inherit'` and
   reads in blocking mode, the kernel returns EAGAIN / partial multi-byte
   sequences — this is what corrupts CJK/IME cursors.
2. **Buffered keystrokes** (the double-space switch, in-flight typing) leak into
   the child, plus a **cooked-mode echo race** after Ink unmounts.
3. **Signal handlers bypass `finally` blocks**, leaving the shell stuck in raw
   mode when killed during remote mode.
4. A binary-installed Claude child (e.g. Homebrew) can become an **orphan
   competing for the TTY** because inherited-stdio signals don't cascade.

## Changes

- `claudeLocal.ts`: force `setBlocking(true)` on the stdin fd before spawning
  Claude, clearing O_NONBLOCK so the child reads whole bytes.
- `utils/terminalStdinCleanup.ts` (new): `cleanupStdinAfterInk()` drains buffered
  stdin with raw mode kept on, then pauses; keeps raw mode through the handoff to
  local mode and restores cooked mode on exit. Replaces the previous ad-hoc
  terminal reset (`pause` + `ref` + DECSTR soft reset).
- `claudeRemoteLauncher.ts`: unmount Ink first, then drain via the helper.
- `runClaude.ts`: restore the terminal at the top of `cleanup()` before any async
  work / `process.exit()`.
- `claude_version_utils.cjs`: forward `SIGTERM`/`SIGINT`/`SIGHUP` to the spawned
  Claude binary (binary-install path), with `SIGKILL` escalation after 2s and
  conventional exit codes.

## Testing

- [x] Tested locally
- [x] Existing tests pass
- [x] New tests added — `terminalStdinCleanup.test.ts` (4 cases: no-op on
  non-TTY, exit-path cooked restore, drain + keep-raw handoff, drain + cooked)

Manual testing:

- Reproduced #24 (switch remote→local, then type Chinese) and confirmed the
  cursor/input corruption is gone.
- `yarn typecheck` passes in `packages/happy-cli`.

## Related issues

Closes #24
