### PR TITLE
fix(cli,app): allow machine-scoped RPC to access paths outside homedir

### DIFF
--- a/packages/happy-app/sources/app/(app)/machine/[id].tsx
+++ b/packages/happy-app/sources/app/(app)/machine/[id].tsx
@@ -444,7 +444,9 @@ export default function MachineDetailScreen() {
         if (!machineId) return;
         const gitCheck = await machineBash(machineId, 'git rev-parse --git-dir', selectedPath);
         if (!gitCheck.success) {
-            Modal.alert(t('common.error'), t('newSession.worktree.notGitRepo'));
+            const stderr = gitCheck.stderr?.trim() || '';
+            const isNotRepo = !stderr || stderr.includes('not a git repository');
+            Modal.alert(t('common.error'), isNotRepo ? t('newSession.worktree.notGitRepo') : stderr);
             return;
         }
         const displayName = selectedPath.split('/').filter(Boolean).pop() || 'repo';
@@ -502,7 +504,9 @@ export default function MachineDetailScreen() {
         if (!machineId) return;
         const gitCheck = await machineBash(machineId, 'git rev-parse --git-dir', selectedPath);
         if (!gitCheck.success) {
-            Modal.alert(t('common.error'), t('newSession.worktree.notGitRepo'));
+            const stderr = gitCheck.stderr?.trim() || '';
+            const isNotRepo = !stderr || stderr.includes('not a git repository');
+            Modal.alert(t('common.error'), isNotRepo ? t('newSession.worktree.notGitRepo') : stderr);
             return;
         }
         const displayName = selectedPath.split('/').filter(Boolean).pop() || 'repo';

--- a/packages/happy-app/sources/app/(app)/new/index.tsx
+++ b/packages/happy-app/sources/app/(app)/new/index.tsx
@@ -823,7 +823,9 @@ function NewSessionWizard() {
         if (!selectedMachineId) return;
         const gitCheck = await machineBash(selectedMachineId, 'git rev-parse --git-dir', selectedPath);
         if (!gitCheck.success) {
-            Modal.alert(t('common.error'), t('newSession.worktree.notGitRepo'));
+            const stderr = gitCheck.stderr?.trim() || '';
+            const isNotRepo = !stderr || stderr.includes('not a git repository');
+            Modal.alert(t('common.error'), isNotRepo ? t('newSession.worktree.notGitRepo') : stderr);
             return;
         }
         const displayName = selectedPath.split('/').filter(Boolean).pop() || 'repo';

--- a/packages/happy-cli/src/api/apiMachine.ts
+++ b/packages/happy-cli/src/api/apiMachine.ts
@@ -4,7 +4,6 @@
  */
 
 import { io, Socket } from 'socket.io-client';
-import { homedir } from 'node:os';
 import { logger } from '@/ui/logger';
 import { configuration } from '@/configuration';
 import { isDebug } from '@/utils/env';
@@ -194,7 +193,7 @@ export class ApiMachineClient {
             logger: (msg, data) => logger.debug(msg, data)
         });
 
-        registerCommonHandlers(this.rpcHandlerManager, homedir());
+        registerCommonHandlers(this.rpcHandlerManager, '/');
         registerOpenClawHandlers(this.rpcHandlerManager, {
             key: this.machine.encryptionKey
         });

--- a/packages/happy-cli/src/modules/common/pathSecurity.test.ts
+++ b/packages/happy-cli/src/modules/common/pathSecurity.test.ts
@@ -26,4 +26,18 @@ describe('validatePath', () => {
         expect(validatePath('.', workingDir).valid).toBe(true);
         expect(validatePath(workingDir, workingDir).valid).toBe(true);
     });
+
+    describe('root working directory', () => {
+        it('should allow any absolute path when workingDirectory is /', () => {
+            expect(validatePath('/vol1', '/').valid).toBe(true);
+            expect(validatePath('/vol1/1000/project', '/').valid).toBe(true);
+            expect(validatePath('/home/user/project', '/').valid).toBe(true);
+            expect(validatePath('/etc/passwd', '/').valid).toBe(true);
+        });
+
+        it('should allow root itself', () => {
+            expect(validatePath('/', '/').valid).toBe(true);
+            expect(validatePath('.', '/').valid).toBe(true);
+        });
+    });
 });

--- a/packages/happy-cli/src/modules/common/pathSecurity.ts
+++ b/packages/happy-cli/src/modules/common/pathSecurity.ts
@@ -18,7 +18,8 @@ export function validatePath(targetPath: string, workingDirectory: string): Path
 
     // Check if the resolved target path starts with the working directory
     // This prevents access to files outside the working directory
-    if (!resolvedTarget.startsWith(resolvedWorkingDir + '/') && resolvedTarget !== resolvedWorkingDir) {
+    const prefix = resolvedWorkingDir.endsWith('/') ? resolvedWorkingDir : resolvedWorkingDir + '/';
+    if (!resolvedTarget.startsWith(prefix) && resolvedTarget !== resolvedWorkingDir) {
         return {
             valid: false,
             error: `Access denied: Path '${targetPath}' is outside the working directory`

--- a/packages/happy-cli/src/modules/common/registerCommonHandlers.ts
+++ b/packages/happy-cli/src/modules/common/registerCommonHandlers.ts
@@ -186,9 +186,7 @@ export function registerCommonHandlers(rpcHandlerManager: RpcHandlerManager, wor
         logger.debug('Shell command request:', data.command);
 
         // Validate cwd if provided
-        // Special case: "/" means "use shell's default cwd" (used by CLI detection)
-        // Security: Still validate all other paths to prevent directory traversal
-        if (data.cwd && data.cwd !== '/') {
+        if (data.cwd) {
             const validation = validatePath(data.cwd, workingDirectory);
             if (!validation.valid) {
                 return { success: false, error: validation.error };
@@ -196,11 +194,8 @@ export function registerCommonHandlers(rpcHandlerManager: RpcHandlerManager, wor
         }
 
         try {
-            // Build options with shell enabled by default
-            // Note: ExecOptions doesn't support boolean for shell, but exec() uses the default shell when shell is undefined
-            // If cwd is "/", use undefined to let shell use its default (respects user's PATH)
             const options: ExecOptions = {
-                cwd: data.cwd === '/' ? undefined : data.cwd,
+                cwd: data.cwd || undefined,
                 timeout: data.timeout || 30000, // Default 30 seconds timeout
             };
 


### PR DESCRIPTION
## Summary

Machine-scoped RPC 的路径校验使用 `homedir()` 作为安全边界，导致 NAS 挂载或其他 home 目录之外的路径（如 `/vol1/1000/project/`）无法在「选择文件夹」中正常加载，报「加载目录失败」。

改为使用 `'/'`，让路径校验交给操作系统权限控制。这不会降低安全性，因为 `bash` handler 已经对 `cwd: '/'` 豁免了路径校验，认证 + E2E 加密才是真正的安全边界。

## Changes

- **`apiMachine.ts`**: `registerCommonHandlers` 的 `workingDirectory` 参数从 `homedir()` 改为 `'/'`，移除未使用的 `homedir` import
- **`pathSecurity.ts`**: 修复 `validatePath` 在 `workingDirectory = '/'` 时的前缀拼接 bug（`'/' + '/' = '//'` 导致所有路径被拒绝），改用通用的 `endsWith('/')` 判断
- **`registerCommonHandlers.ts`**: 移除 bash handler 对 `cwd: '/'` 的哨兵映射（原来 `'/'` 被映射为 `undefined` 即进程默认 cwd，导致 FolderPickerSheet 浏览 `/` 时列出 daemon 工作目录而非真实根目录）
- **`machine/[id].tsx` + `new/index.tsx`**: git 仓库检查失败时，区分「不是 git 仓库」和其他错误（如 `dubious ownership`），后者透传 git 原始错误信息而非一律报「Worktree 需要 git 仓库」

## Testing

- [x] Tested locally
- [x] Existing tests pass（`yarn typecheck` + `pathSecurity.test.ts` 全部通过）
- [x] New tests added（`pathSecurity.test.ts` 新增 root workingDirectory 测试用例）

## Related issues

Closes #26