### PR TITLE
fix(push): bind device token to one account

### DIFF
--- a/packages/happy-app/sources/app/(app)/server.tsx
+++ b/packages/happy-app/sources/app/(app)/server.tsx
@@ -146,9 +146,10 @@ export default function ServerConfigScreen() {
         );
 
         if (confirmed) {
-            setServerUrl(inputUrl);
-            await resolveServerConfig();
-            await logout();
+            await logout(async () => {
+                setServerUrl(inputUrl);
+                await resolveServerConfig();
+            });
             navigation.dispatch(
                 CommonActions.reset({
                     index: 0,
@@ -166,10 +167,11 @@ export default function ServerConfigScreen() {
         );
 
         if (confirmed) {
-            setServerUrl(null);
-            await resolveServerConfig();
-            setInputUrl('');
-            await logout();
+            await logout(async () => {
+                setServerUrl(null);
+                await resolveServerConfig();
+                setInputUrl('');
+            });
             navigation.dispatch(
                 CommonActions.reset({
                     index: 0,

--- a/packages/happy-app/sources/auth/AuthContext.tsx
+++ b/packages/happy-app/sources/auth/AuthContext.tsx
@@ -2,16 +2,17 @@ import { createContext, useContext, useState, useEffect, ReactNode } from 'react
 import { Platform } from 'react-native';
 import { reloadAppAsync } from 'expo';
 import { TokenStorage, AuthCredentials } from '@/auth/tokenStorage';
-import { syncCreate } from '@/sync/sync';
+import { stopPushTokenRegistration, syncCreate } from '@/sync/sync';
 import { clearPersistence } from '@/sync/persistence';
 import { messageRepository } from '@/sync/messagesStore/messageRepository';
 import { trackLogout } from '@/track';
+import { unregisterCurrentPushToken } from '@/sync/pushTokenLogout';
 
 interface AuthContextType {
     isAuthenticated: boolean;
     credentials: AuthCredentials | null;
     login: (token: string, secret: string) => Promise<void>;
-    logout: () => Promise<void>;
+    logout: (afterPushCleanup?: () => void | Promise<void>) => Promise<void>;
 }
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
@@ -37,8 +38,13 @@ export function AuthProvider({ children, initialCredentials }: { children: React
         }
     };
 
-    const logout = async () => {
+    const logout = async (afterPushCleanup?: () => void | Promise<void>) => {
         trackLogout();
+        if (credentials) {
+            await stopPushTokenRegistration();
+            await unregisterCurrentPushToken(credentials).catch(() => {});
+        }
+        await afterPushCleanup?.();
         clearPersistence();
         await messageRepository.clearAll().catch(() => {});
         await TokenStorage.removeCredentials();

--- a/packages/happy-app/sources/sync/apiPush.test.ts
+++ b/packages/happy-app/sources/sync/apiPush.test.ts
@@ -1,0 +1,52 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const fetchMock = vi.fn();
+global.fetch = fetchMock;
+
+vi.mock('./serverConfig', () => ({ getServerUrl: () => 'https://server.example' }));
+vi.mock('@/utils/time', () => ({
+    backoff: (callback: () => Promise<unknown>) => callback(),
+}));
+
+import { deletePushToken, registerPushToken } from './apiPush';
+
+describe('push token API', () => {
+    beforeEach(() => {
+        fetchMock.mockReset().mockResolvedValue({
+            ok: true,
+            json: async () => ({ success: true }),
+        });
+    });
+
+    it('registers the current device token', async () => {
+        const controller = new AbortController();
+        await registerPushToken(
+            { token: 'auth-token', secret: 'secret' },
+            'push-token',
+            controller.signal,
+        );
+
+        expect(fetchMock).toHaveBeenCalledWith(
+            'https://server.example/v1/push-tokens',
+            expect.objectContaining({
+                method: 'POST',
+                body: JSON.stringify({ token: 'push-token' }),
+                signal: controller.signal,
+            }),
+        );
+    });
+
+    it('passes an abort signal when unregistering the token', async () => {
+        const controller = new AbortController();
+        await deletePushToken(
+            { token: 'auth-token', secret: 'secret' },
+            'push/token',
+            controller.signal,
+        );
+
+        expect(fetchMock).toHaveBeenCalledWith(
+            'https://server.example/v1/push-tokens/push%2Ftoken',
+            expect.objectContaining({ signal: controller.signal }),
+        );
+    });
+});

--- a/packages/happy-app/sources/sync/apiPush.ts
+++ b/packages/happy-app/sources/sync/apiPush.ts
@@ -1,28 +1,49 @@
 import { AuthCredentials } from '@/auth/tokenStorage';
-import { backoff } from '@/utils/time';
 import { getServerUrl } from './serverConfig';
 
-export async function registerPushToken(credentials: AuthCredentials, token: string): Promise<void> {
+export async function registerPushToken(
+    credentials: AuthCredentials,
+    token: string,
+    signal?: AbortSignal,
+): Promise<void> {
     const API_ENDPOINT = getServerUrl();
-    await backoff(async () => {
-        const response = await fetch(`${API_ENDPOINT}/v1/push-tokens`, {
-            method: 'POST',
-            headers: {
-                'Authorization': `Bearer ${credentials.token}`,
-                'Content-Type': 'application/json'
-            },
-            body: JSON.stringify({ token })
-        });
-
-        if (!response.ok) {
-            throw new Error(`Failed to register push token: ${response.status}`);
-        }
-
-        const data = await response.json();
-        if (!data.success) {
-            throw new Error('Failed to register push token');
-        }
+    const response = await fetch(`${API_ENDPOINT}/v1/push-tokens`, {
+        method: 'POST',
+        headers: {
+            'Authorization': `Bearer ${credentials.token}`,
+            'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({ token }),
+        signal,
     });
+
+    if (!response.ok) {
+        throw new Error(`Failed to register push token: ${response.status}`);
+    }
+
+    const data = await response.json();
+    if (!data.success) {
+        throw new Error('Failed to register push token');
+    }
+}
+
+export async function deletePushToken(
+    credentials: AuthCredentials,
+    token: string,
+    signal?: AbortSignal,
+): Promise<void> {
+    const API_ENDPOINT = getServerUrl();
+    const response = await fetch(`${API_ENDPOINT}/v1/push-tokens/${encodeURIComponent(token)}`, {
+        method: 'DELETE',
+        headers: {
+            'Authorization': `Bearer ${credentials.token}`
+        },
+        signal,
+    });
+
+    if (!response.ok) {
+        throw new Error(`Failed to delete push token: ${response.status}`);
+    }
 }
 
 export async function resetBadgeCount(credentials: AuthCredentials): Promise<void> {

--- a/packages/happy-app/sources/sync/pushTokenLogout.test.ts
+++ b/packages/happy-app/sources/sync/pushTokenLogout.test.ts
@@ -1,0 +1,81 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+    deletePushToken: vi.fn(),
+    getExpoPushTokenAsync: vi.fn(),
+    unregisterForNotificationsAsync: vi.fn(),
+}));
+
+vi.mock('expo-constants', () => ({
+    default: {
+        expoConfig: { extra: { eas: { projectId: 'project-1' } } },
+    },
+}));
+vi.mock('expo-notifications', () => ({
+    getExpoPushTokenAsync: mocks.getExpoPushTokenAsync,
+    unregisterForNotificationsAsync: mocks.unregisterForNotificationsAsync,
+}));
+vi.mock('react-native', () => ({ Platform: { OS: 'android' } }));
+vi.mock('./apiPush', () => ({ deletePushToken: mocks.deletePushToken }));
+
+import { unregisterCurrentPushToken } from './pushTokenLogout';
+
+describe('unregisterCurrentPushToken', () => {
+    beforeEach(() => {
+        mocks.deletePushToken.mockReset().mockResolvedValue(undefined);
+        mocks.getExpoPushTokenAsync.mockReset().mockResolvedValue({ data: 'expo-token' });
+        mocks.unregisterForNotificationsAsync.mockReset().mockResolvedValue(undefined);
+    });
+
+    it('removes the Expo token for only the current installation', async () => {
+        const credentials = { token: 'auth-token', secret: 'secret' };
+        await unregisterCurrentPushToken(credentials, 100);
+
+        expect(mocks.getExpoPushTokenAsync).toHaveBeenCalledWith({ projectId: 'project-1' });
+        expect(mocks.deletePushToken).toHaveBeenCalledWith(
+            credentials,
+            'expo-token',
+            expect.any(AbortSignal),
+        );
+        expect(mocks.unregisterForNotificationsAsync).toHaveBeenCalledOnce();
+    });
+
+    it('waits for server cleanup before unregistering the device locally', async () => {
+        let resolveToken: ((value: { data: string }) => void) | undefined;
+        mocks.getExpoPushTokenAsync.mockReturnValue(new Promise((resolve) => {
+            resolveToken = resolve;
+        }));
+
+        const unregistering = unregisterCurrentPushToken(
+            { token: 'auth-token', secret: 'secret' },
+            100,
+        );
+
+        await vi.waitFor(() => expect(mocks.getExpoPushTokenAsync).toHaveBeenCalledOnce());
+        expect(mocks.unregisterForNotificationsAsync).not.toHaveBeenCalled();
+
+        resolveToken?.({ data: 'expo-token' });
+        await unregistering;
+
+        expect(mocks.deletePushToken.mock.invocationCallOrder[0]).toBeLessThan(
+            mocks.unregisterForNotificationsAsync.mock.invocationCallOrder[0],
+        );
+    });
+
+    it('unregisters the device locally when the server cleanup fails', async () => {
+        mocks.deletePushToken.mockRejectedValue(new Error('server unavailable'));
+
+        await unregisterCurrentPushToken({ token: 'auth-token', secret: 'secret' }, 100);
+
+        expect(mocks.unregisterForNotificationsAsync).toHaveBeenCalledOnce();
+    });
+
+    it('does not block logout when Expo token lookup stalls', async () => {
+        mocks.getExpoPushTokenAsync.mockReturnValue(new Promise(() => {}));
+
+        await unregisterCurrentPushToken({ token: 'auth-token', secret: 'secret' }, 1);
+
+        expect(mocks.deletePushToken).not.toHaveBeenCalled();
+        expect(mocks.unregisterForNotificationsAsync).toHaveBeenCalledOnce();
+    });
+});

--- a/packages/happy-app/sources/sync/pushTokenLogout.ts
+++ b/packages/happy-app/sources/sync/pushTokenLogout.ts
@@ -1,0 +1,56 @@
+import Constants from 'expo-constants';
+import * as Notifications from 'expo-notifications';
+import { Platform } from 'react-native';
+import type { AuthCredentials } from '@/auth/tokenStorage';
+import { deletePushToken } from './apiPush';
+
+const LOGOUT_UNREGISTER_TIMEOUT_MS = 3_000;
+
+async function waitWithTimeout(
+    task: Promise<void>,
+    timeoutMs: number,
+    onTimeout?: () => void,
+): Promise<void> {
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+    try {
+        await Promise.race([
+            task,
+            new Promise<void>((resolve) => {
+                timeout = setTimeout(() => {
+                    onTimeout?.();
+                    resolve();
+                }, timeoutMs);
+            }),
+        ]);
+    } finally {
+        if (timeout) {
+            clearTimeout(timeout);
+        }
+    }
+}
+
+export async function unregisterCurrentPushToken(
+    credentials: AuthCredentials,
+    timeoutMs: number = LOGOUT_UNREGISTER_TIMEOUT_MS,
+): Promise<void> {
+    if (Platform.OS === 'web') {
+        return;
+    }
+
+    const controller = new AbortController();
+    const unregister = (async () => {
+        const projectId = Constants?.expoConfig?.extra?.eas?.projectId ?? Constants?.easConfig?.projectId;
+        const expoToken = await Notifications.getExpoPushTokenAsync({ projectId });
+        await deletePushToken(credentials, expoToken.data, controller.signal);
+    })();
+    try {
+        await waitWithTimeout(
+            unregister.catch(() => {}),
+            timeoutMs,
+            () => controller.abort(),
+        );
+    } finally {
+        controller.abort();
+        await Notifications.unregisterForNotificationsAsync().catch(() => {});
+    }
+}

--- a/packages/happy-app/sources/sync/pushTokenRegistrationGate.test.ts
+++ b/packages/happy-app/sources/sync/pushTokenRegistrationGate.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it, vi } from 'vitest';
+import { PushTokenRegistrationGate } from './pushTokenRegistrationGate';
+
+describe('PushTokenRegistrationGate', () => {
+    it('aborts and waits for an active registration before stopping', async () => {
+        const gate = new PushTokenRegistrationGate();
+        let release: (() => void) | undefined;
+        const task = vi.fn((signal: AbortSignal) => new Promise<void>((resolve) => {
+            signal.addEventListener('abort', () => {
+                release = resolve;
+            }, { once: true });
+        }));
+
+        const registration = gate.run(task);
+        const stopping = gate.stop(100);
+
+        expect(task.mock.calls[0]?.[0].aborted).toBe(true);
+        expect(release).toBeDefined();
+        release?.();
+        await expect(stopping).resolves.toBeUndefined();
+        await expect(registration).resolves.toBeUndefined();
+    });
+
+    it('does not start registrations after it has stopped', async () => {
+        const gate = new PushTokenRegistrationGate();
+        const task = vi.fn().mockResolvedValue(undefined);
+
+        await gate.stop();
+        await gate.run(task);
+
+        expect(task).not.toHaveBeenCalled();
+    });
+
+    it('does not allow a late task to mutate after stop times out', async () => {
+        const gate = new PushTokenRegistrationGate();
+        let release: (() => void) | undefined;
+        const mutate = vi.fn();
+        const registration = gate.run(async (_signal, startMutation) => {
+            await new Promise<void>((resolve) => {
+                release = resolve;
+            });
+            if (startMutation()) {
+                mutate();
+            }
+        });
+
+        await gate.stop(1);
+        release?.();
+        await registration;
+
+        expect(mutate).not.toHaveBeenCalled();
+    });
+
+    it('waits past the timeout when a server mutation has started', async () => {
+        const gate = new PushTokenRegistrationGate();
+        let release: (() => void) | undefined;
+        const registration = gate.run(async (signal, startMutation) => {
+            expect(startMutation()).toBe(true);
+            await new Promise<void>((resolve) => {
+                release = resolve;
+            });
+            expect(signal.aborted).toBe(false);
+        });
+
+        let stopped = false;
+        const stopping = gate.stop(1).then(() => {
+            stopped = true;
+        });
+        await new Promise((resolve) => setTimeout(resolve, 10));
+
+        expect(stopped).toBe(false);
+        release?.();
+        await stopping;
+        await registration;
+    });
+});

--- a/packages/happy-app/sources/sync/pushTokenRegistrationGate.ts
+++ b/packages/happy-app/sources/sync/pushTokenRegistrationGate.ts
@@ -1,0 +1,70 @@
+const STOP_TIMEOUT_MS = 3_000;
+
+export class PushTokenRegistrationGate {
+    private stopped = false;
+    private activeController: AbortController | null = null;
+    private activeTask: Promise<void> | null = null;
+    private activeMutationStarted = false;
+
+    async run(
+        task: (signal: AbortSignal, startMutation: () => boolean) => Promise<void>,
+    ): Promise<void> {
+        if (this.stopped) {
+            return;
+        }
+
+        const controller = new AbortController();
+        const startMutation = () => {
+            if (this.stopped || controller.signal.aborted) {
+                return false;
+            }
+            this.activeMutationStarted = true;
+            return true;
+        };
+        const activeTask = task(controller.signal, startMutation);
+        this.activeController = controller;
+        this.activeTask = activeTask;
+
+        try {
+            await activeTask;
+        } finally {
+            if (this.activeTask === activeTask) {
+                this.activeController = null;
+                this.activeTask = null;
+                this.activeMutationStarted = false;
+            }
+        }
+    }
+
+    async stop(timeoutMs: number = STOP_TIMEOUT_MS): Promise<void> {
+        this.stopped = true;
+
+        const activeTask = this.activeTask;
+        if (!activeTask) {
+            return;
+        }
+
+        // Once a server mutation has started, let it finish before logout deletes the token.
+        // Aborting or timing out here could allow a late registration to run after that delete.
+        if (this.activeMutationStarted) {
+            await activeTask.catch(() => {});
+            return;
+        }
+
+        this.activeController?.abort();
+
+        let timeout: ReturnType<typeof setTimeout> | undefined;
+        try {
+            await Promise.race([
+                activeTask.catch(() => {}),
+                new Promise<void>((resolve) => {
+                    timeout = setTimeout(resolve, timeoutMs);
+                }),
+            ]);
+        } finally {
+            if (timeout) {
+                clearTimeout(timeout);
+            }
+        }
+    }
+}

--- a/packages/happy-app/sources/sync/sync.ts
+++ b/packages/happy-app/sources/sync/sync.ts
@@ -21,6 +21,7 @@ import { ActivityUpdateAccumulator } from './reducer/activityUpdateAccumulator';
 import { randomUUID, getRandomBytes } from 'expo-crypto';
 import * as Notifications from 'expo-notifications';
 import { registerPushToken } from './apiPush';
+import { PushTokenRegistrationGate } from './pushTokenRegistrationGate';
 import { Platform, AppState } from 'react-native';
 import { isRunningOnMac } from '@/utils/platform';
 import { NormalizedMessage, normalizeRawMessage, RawRecord, RawRecordSchema, ImageContent } from './typesRaw';
@@ -242,6 +243,7 @@ class Sync {
     private profileSync: InvalidateSync;
     private machinesSync: InvalidateSync;
     private pushTokenSync: InvalidateSync;
+    private pushTokenRegistrationGate = new PushTokenRegistrationGate();
     private nativeUpdateSync: InvalidateSync;
     private artifactsSync: InvalidateSync;
     private friendsSync: InvalidateSync;
@@ -300,7 +302,9 @@ class Sync {
         const registerPushToken = async () => {
             // Keep push token registration enabled in dev builds too:
             // Android contributors often validate notifications on dev clients.
-            await this.registerPushToken();
+            await this.pushTokenRegistrationGate.run(
+                (signal, startMutation) => this.registerPushToken(signal, startMutation),
+            );
         }
         this.pushTokenSync = new InvalidateSync(registerPushToken);
         this.activityAccumulator = new ActivityUpdateAccumulator(this.flushActivityUpdates.bind(this), 2000);
@@ -3948,7 +3952,15 @@ class Sync {
     }
 
 
-    private registerPushToken = async () => {
+    public stopPushTokenRegistration = async () => {
+        this.pushTokenSync.stop();
+        await this.pushTokenRegistrationGate.stop();
+    }
+
+    private registerPushToken = async (
+        signal: AbortSignal,
+        startMutation: () => boolean,
+    ) => {
         log.log('registerPushToken');
         // Only register on mobile platforms
         if (Platform.OS === 'web') {
@@ -3957,11 +3969,17 @@ class Sync {
 
         // Request permission
         const { status: existingStatus } = await Notifications.getPermissionsAsync();
+        if (signal.aborted) {
+            return;
+        }
         let finalStatus = existingStatus;
         log.log('existingStatus: ' + JSON.stringify(existingStatus));
 
         if (existingStatus !== 'granted') {
             const { status } = await Notifications.requestPermissionsAsync();
+            if (signal.aborted) {
+                return;
+            }
             finalStatus = status;
         }
         log.log('finalStatus: ' + JSON.stringify(finalStatus));
@@ -3975,14 +3993,21 @@ class Sync {
         const projectId = Constants?.expoConfig?.extra?.eas?.projectId ?? Constants?.easConfig?.projectId;
 
         const tokenData = await Notifications.getExpoPushTokenAsync({ projectId });
+        if (signal.aborted) {
+            return;
+        }
         log.log('tokenData: ' + JSON.stringify(tokenData));
 
         // Register with server
+        if (!startMutation()) {
+            return;
+        }
         try {
             await registerPushToken(this.credentials, tokenData.data);
             log.log('Push token registered successfully');
         } catch (error) {
             log.log('Failed to register push token: ' + JSON.stringify(error));
+            throw error;
         }
     }
 
@@ -5345,6 +5370,10 @@ export async function syncRestore(credentials: AuthCredentials) {
     }
     isInitialized = true;
     await syncInit(credentials, true);
+}
+
+export async function stopPushTokenRegistration() {
+    await sync.stopPushTokenRegistration();
 }
 
 async function syncInit(credentials: AuthCredentials, restore: boolean) {

--- a/packages/happy-server/prisma/migrations/20260804160000_make_push_token_globally_unique/migration.sql
+++ b/packages/happy-server/prisma/migrations/20260804160000_make_push_token_globally_unique/migration.sql
@@ -1,0 +1,29 @@
+BEGIN;
+
+LOCK TABLE "AccountPushToken" IN ACCESS EXCLUSIVE MODE;
+
+WITH "ranked_tokens" AS (
+  SELECT
+    "id",
+    ROW_NUMBER() OVER (
+      PARTITION BY "token"
+      ORDER BY "updatedAt" DESC, "createdAt" DESC, "id" DESC
+    ) AS "position"
+  FROM "AccountPushToken"
+)
+DELETE FROM "AccountPushToken"
+WHERE "id" IN (
+  SELECT "id"
+  FROM "ranked_tokens"
+  WHERE "position" > 1
+);
+
+DROP INDEX "AccountPushToken_accountId_token_key";
+
+CREATE UNIQUE INDEX "AccountPushToken_token_key"
+ON "AccountPushToken"("token");
+
+CREATE INDEX "AccountPushToken_accountId_idx"
+ON "AccountPushToken"("accountId");
+
+COMMIT;

--- a/packages/happy-server/prisma/schema.prisma
+++ b/packages/happy-server/prisma/schema.prisma
@@ -91,11 +91,11 @@ model AccountPushToken {
   id        String   @id @default(cuid())
   accountId String
   account   Account  @relation(fields: [accountId], references: [id])
-  token     String
+  token     String   @unique
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
-  @@unique([accountId, token])
+  @@index([accountId])
 }
 
 //

--- a/packages/happy-server/sources/app/api/routes/pushRoutes.test.ts
+++ b/packages/happy-server/sources/app/api/routes/pushRoutes.test.ts
@@ -1,0 +1,80 @@
+import fastify from 'fastify';
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { serializerCompiler, validatorCompiler } from 'fastify-type-provider-zod';
+import type { Fastify } from '../types';
+
+const mocks = vi.hoisted(() => ({
+    upsert: vi.fn(),
+    deleteMany: vi.fn(),
+    findMany: vi.fn(),
+    updateAccount: vi.fn(),
+}));
+
+vi.mock('@/storage/db', () => ({
+    db: {
+        accountPushToken: {
+            upsert: mocks.upsert,
+            deleteMany: mocks.deleteMany,
+            findMany: mocks.findMany,
+        },
+        account: { update: mocks.updateAccount },
+    },
+}));
+
+import { pushRoutes } from './pushRoutes';
+
+describe('push token ownership', () => {
+    let app: ReturnType<typeof fastify>;
+
+    beforeAll(async () => {
+        app = fastify();
+        app.setValidatorCompiler(validatorCompiler);
+        app.setSerializerCompiler(serializerCompiler);
+        app.decorate('authenticate', async (request: any) => {
+            request.userId = 'account-b';
+        });
+        pushRoutes(app as unknown as Fastify);
+        await app.ready();
+    });
+
+    beforeEach(() => {
+        mocks.upsert.mockReset().mockResolvedValue({});
+        mocks.deleteMany.mockReset().mockResolvedValue({ count: 1 });
+    });
+
+    it('transfers an existing device token to the authenticated account', async () => {
+        const response = await app.inject({
+            method: 'POST',
+            url: '/v1/push-tokens',
+            payload: { token: 'shared-device-token' },
+        });
+
+        expect(response.statusCode).toBe(200);
+        expect(mocks.upsert).toHaveBeenCalledWith({
+            where: { token: 'shared-device-token' },
+            update: {
+                accountId: 'account-b',
+                updatedAt: expect.any(Date),
+            },
+            create: {
+                accountId: 'account-b',
+                token: 'shared-device-token',
+            },
+        });
+    });
+
+    it('scopes unregistering to the authenticated account', async () => {
+        const response = await app.inject({
+            method: 'DELETE',
+            url: '/v1/push-tokens/shared-device-token',
+        });
+
+        expect(response.statusCode).toBe(200);
+        expect(mocks.deleteMany).toHaveBeenCalledWith({
+            where: {
+                accountId: 'account-b',
+                token: 'shared-device-token',
+            },
+        });
+    });
+});

--- a/packages/happy-server/sources/app/api/routes/pushRoutes.ts
+++ b/packages/happy-server/sources/app/api/routes/pushRoutes.ts
@@ -27,12 +27,10 @@ export function pushRoutes(app: Fastify) {
         try {
             await db.accountPushToken.upsert({
                 where: {
-                    accountId_token: {
-                        accountId: userId,
-                        token: token
-                    }
+                    token
                 },
                 update: {
+                    accountId: userId,
                     updatedAt: new Date()
                 },
                 create: {


### PR DESCRIPTION
## Summary

Ensure each Expo push token belongs to only one account, preventing a shared device from continuing to receive notifications for a previously signed-in account.

## Changes

- Make push tokens globally unique and migrate existing duplicate rows to their most recently updated owner
- Transfer token ownership to the authenticated account when a device registers
- Stop in-flight token registration and unregister the current device token during logout
- Keep token deletion scoped to the authenticated account to avoid stale logout requests deleting a transferred token
- Add app and server tests for registration, ownership transfer, logout cleanup, and cancellation

## Testing

- [x] Tested locally
- [ ] Existing tests pass
- [x] New tests added (if applicable)

Passed:
- `happy-app: yarn typecheck`
- `happy-app: yarn test --run` (915 passed, 57 skipped)
- `happy-server: yarn build`
- `happy-server: npx vitest run sources/app/api/routes/pushRoutes.test.ts`
- `happy-server: npx prisma validate`

The full `happy-server` suite still has three unrelated existing failures in `processImage.spec.ts` and orchestrator integration tests.

## Related issues

N/A