### PR TITLE
feat(desktop): support window-wide image drop

### DIFF
--- a/packages/happy-app/sources/-session/SessionView.tsx
+++ b/packages/happy-app/sources/-session/SessionView.tsx
@@ -47,6 +47,7 @@ import { useUnistyles } from 'react-native-unistyles';
 
 const SILENT_REFRESH_INDICATOR_DELAY_MS = 3000;
 const SILENT_REFRESH_FAILED_TIMEOUT_MS = 12000;
+const MAX_SESSION_IMAGES = 4;
 
 // Gap between the leading header-right action (orchestrator / new-session) and the avatar.
 // Web (custom header) gets a roomier gap; native apps stay at the 4px baseline that
@@ -484,7 +485,7 @@ function SessionViewLoaded({ sessionId, session }: { sessionId: string, session:
         clearImages,
         initImages,
         canAddMore,
-    } = useImagePicker({ maxImages: 4 });
+    } = useImagePicker({ maxImages: MAX_SESSION_IMAGES });
 
     // Use draft hook for auto-saving message drafts
     const { clearDraft } = useDraft(sessionId, message, setMessage, images, initImages);
@@ -946,13 +947,68 @@ function SessionViewLoaded({ sessionId, session }: { sessionId: string, session:
     const handleImageDrop = React.useCallback(async (files: File[]) => {
         if (!canAddMore || !supportsImages) return;
 
-        for (const file of files) {
-            if (file.type.startsWith('image/') && canAddMore) {
-                const url = URL.createObjectURL(file);
-                await addImageFromUri(url, file.type);
-            }
+        const imageFiles = files
+            .filter((file) => file.type.startsWith('image/'))
+            .slice(0, Math.max(0, MAX_SESSION_IMAGES - images.length));
+        for (const file of imageFiles) {
+            const url = URL.createObjectURL(file);
+            await addImageFromUri(url, file.type);
         }
-    }, [canAddMore, supportsImages, addImageFromUri]);
+    }, [addImageFromUri, canAddMore, images.length, supportsImages]);
+
+    const [isImageDragging, setIsImageDragging] = React.useState(false);
+    const imageDragDepthRef = React.useRef(0);
+
+    React.useEffect(() => {
+        if (Platform.OS !== 'web' || !isFocused) return;
+
+        const hasFiles = (event: DragEvent) => event.dataTransfer?.types.includes('Files') === true;
+        const canAcceptImages = supportsImages && canAddMore;
+        const resetDragState = () => {
+            imageDragDepthRef.current = 0;
+            setIsImageDragging(false);
+        };
+        const handleDragEnter = (event: DragEvent) => {
+            if (!hasFiles(event)) return;
+            event.preventDefault();
+            if (!canAcceptImages) return;
+            imageDragDepthRef.current += 1;
+            setIsImageDragging(true);
+        };
+        const handleDragLeave = (event: DragEvent) => {
+            if (imageDragDepthRef.current === 0) return;
+            event.preventDefault();
+            imageDragDepthRef.current = Math.max(0, imageDragDepthRef.current - 1);
+            if (imageDragDepthRef.current === 0) setIsImageDragging(false);
+        };
+        const handleDragOver = (event: DragEvent) => {
+            if (!hasFiles(event)) return;
+            event.preventDefault();
+            if (event.dataTransfer) event.dataTransfer.dropEffect = canAcceptImages ? 'copy' : 'none';
+        };
+        const handleDrop = (event: DragEvent) => {
+            if (!hasFiles(event)) return;
+            event.preventDefault();
+            resetDragState();
+            if (!canAcceptImages || !event.dataTransfer) return;
+            const images = Array.from(event.dataTransfer.files).filter((file) => file.type.startsWith('image/'));
+            if (images.length > 0) void handleImageDrop(images);
+        };
+
+        document.addEventListener('dragenter', handleDragEnter);
+        document.addEventListener('dragleave', handleDragLeave);
+        document.addEventListener('dragover', handleDragOver);
+        document.addEventListener('drop', handleDrop);
+        window.addEventListener('blur', resetDragState);
+        return () => {
+            document.removeEventListener('dragenter', handleDragEnter);
+            document.removeEventListener('dragleave', handleDragLeave);
+            document.removeEventListener('dragover', handleDragOver);
+            document.removeEventListener('drop', handleDrop);
+            window.removeEventListener('blur', resetDragState);
+            resetDragState();
+        };
+    }, [canAddMore, handleImageDrop, isFocused, supportsImages]);
 
     // Handle loading more older messages when scrolling to top
     const [minimapItems, setMinimapItems] = React.useState<ConversationMinimapItem[]>([]);
@@ -1241,7 +1297,6 @@ function SessionViewLoaded({ sessionId, session }: { sessionId: string, session:
             onImageButtonPress={handleImageButtonPress}
             supportsImages={supportsImages}
             isUploadingImages={isUploadingImages}
-            onImageDrop={handleImageDrop}
         />
     ) : null;
 
@@ -1298,7 +1353,7 @@ function SessionViewLoaded({ sessionId, session }: { sessionId: string, session:
             {/* Main content area - no padding since header is overlay */}
             <View
                 onLayout={(event) => setContentAreaWidth(event.nativeEvent.layout.width)}
-                style={{ flexBasis: 0, flexGrow: 1, paddingBottom: safeArea.bottom + ((isRunningOnMac() || Platform.OS === 'web') ? 8 : 0) }}
+                style={{ flexBasis: 0, flexGrow: 1, position: 'relative', paddingBottom: safeArea.bottom + ((isRunningOnMac() || Platform.OS === 'web') ? 8 : 0) }}
             >
                 <AgentContentView
                     content={content}
@@ -1306,6 +1361,32 @@ function SessionViewLoaded({ sessionId, session }: { sessionId: string, session:
                     placeholder={placeholder}
                     betweenContentAndInput={pendingQueuePanel}
                 />
+                {isImageDragging && (
+                    <View
+                        pointerEvents="none"
+                        style={{
+                            position: 'absolute',
+                            top: 8,
+                            right: 8,
+                            bottom: 8,
+                            left: 8,
+                            zIndex: 1001,
+                            alignItems: 'center',
+                            justifyContent: 'center',
+                            borderWidth: 2,
+                            borderStyle: 'dashed',
+                            borderColor: theme.colors.button.primary.background,
+                            borderRadius: 8,
+                            backgroundColor: theme.colors.surface,
+                            opacity: 0.96,
+                        }}
+                    >
+                        <Ionicons name="images-outline" size={36} color={theme.colors.text} />
+                        <Text style={{ marginTop: 10, color: theme.colors.text, fontSize: 16, fontWeight: '600' }}>
+                            {t('session.dropImagesToAttach')}
+                        </Text>
+                    </View>
+                )}
             </View >
 
             <ConversationMinimap

--- a/packages/happy-app/sources/text/_default.ts
+++ b/packages/happy-app/sources/text/_default.ts
@@ -772,6 +772,7 @@ export const en = {
         takePhoto: 'Take Photo',
         chooseFromLibrary: 'Choose from Library',
         pasteFromClipboard: 'Paste from Clipboard',
+        dropImagesToAttach: 'Drop images to attach',
         sharing: {
             title: 'Sharing',
             directSharing: 'Direct sharing',

--- a/packages/happy-app/sources/text/translations/ca.ts
+++ b/packages/happy-app/sources/text/translations/ca.ts
@@ -761,6 +761,7 @@ export const ca: TranslationStructure = {
         takePhoto: 'Fes una foto',
         chooseFromLibrary: 'Tria de la galeria',
         pasteFromClipboard: 'Enganxa des del porta-retalls',
+        dropImagesToAttach: 'Deixa anar les imatges per adjuntar-les',
         sharing: {
             title: 'Compartició',
             directSharing: 'Compartició directa',

--- a/packages/happy-app/sources/text/translations/en.ts
+++ b/packages/happy-app/sources/text/translations/en.ts
@@ -778,6 +778,7 @@ export const en: TranslationStructure = {
         takePhoto: 'Take Photo',
         chooseFromLibrary: 'Choose from Library',
         pasteFromClipboard: 'Paste from Clipboard',
+        dropImagesToAttach: 'Drop images to attach',
         sharing: {
             title: 'Sharing',
             directSharing: 'Direct sharing',

--- a/packages/happy-app/sources/text/translations/es.ts
+++ b/packages/happy-app/sources/text/translations/es.ts
@@ -761,6 +761,7 @@ export const es: TranslationStructure = {
         takePhoto: 'Tomar foto',
         chooseFromLibrary: 'Elegir de la galería',
         pasteFromClipboard: 'Pegar desde el portapapeles',
+        dropImagesToAttach: 'Suelta las imágenes para adjuntarlas',
         sharing: {
             title: 'Compartir',
             directSharing: 'Compartir directo',

--- a/packages/happy-app/sources/text/translations/it.ts
+++ b/packages/happy-app/sources/text/translations/it.ts
@@ -791,6 +791,7 @@ export const it: TranslationStructure = {
         takePhoto: 'Scatta foto',
         chooseFromLibrary: 'Scegli dalla galleria',
         pasteFromClipboard: 'Incolla dagli appunti',
+        dropImagesToAttach: 'Rilascia le immagini per allegarle',
         sharing: {
             title: 'Condivisione',
             directSharing: 'Condivisione diretta',

--- a/packages/happy-app/sources/text/translations/ja.ts
+++ b/packages/happy-app/sources/text/translations/ja.ts
@@ -793,6 +793,7 @@ export const ja: TranslationStructure = {
         takePhoto: '写真を撮る',
         chooseFromLibrary: 'ライブラリから選択',
         pasteFromClipboard: 'クリップボードから貼り付け',
+        dropImagesToAttach: 'ドロップして画像を添付',
         sharing: {
             title: '共有',
             directSharing: 'ダイレクト共有',

--- a/packages/happy-app/sources/text/translations/pl.ts
+++ b/packages/happy-app/sources/text/translations/pl.ts
@@ -773,6 +773,7 @@ export const pl: TranslationStructure = {
         takePhoto: 'Zrób zdjęcie',
         chooseFromLibrary: 'Wybierz z galerii',
         pasteFromClipboard: 'Wklej ze schowka',
+        dropImagesToAttach: 'Upuść obrazy, aby je załączyć',
         sharing: {
             title: 'Udostępnianie',
             directSharing: 'Udostępnianie bezpośrednie',

--- a/packages/happy-app/sources/text/translations/pt.ts
+++ b/packages/happy-app/sources/text/translations/pt.ts
@@ -761,6 +761,7 @@ export const pt: TranslationStructure = {
         takePhoto: 'Tirar foto',
         chooseFromLibrary: 'Escolher da galeria',
         pasteFromClipboard: 'Colar da área de transferência',
+        dropImagesToAttach: 'Solte as imagens para anexar',
         sharing: {
             title: 'Compartilhamento',
             directSharing: 'Compartilhamento direto',

--- a/packages/happy-app/sources/text/translations/ru.ts
+++ b/packages/happy-app/sources/text/translations/ru.ts
@@ -934,6 +934,7 @@ export const ru: TranslationStructure = {
         takePhoto: 'Сделать фото',
         chooseFromLibrary: 'Выбрать из галереи',
         pasteFromClipboard: 'Вставить из буфера обмена',
+        dropImagesToAttach: 'Отпустите изображения, чтобы прикрепить их',
         sharing: {
             title: 'Общий доступ',
             directSharing: 'Прямой доступ',

--- a/packages/happy-app/sources/text/translations/zh-Hans.ts
+++ b/packages/happy-app/sources/text/translations/zh-Hans.ts
@@ -763,6 +763,7 @@ export const zhHans: TranslationStructure = {
         takePhoto: '拍照',
         chooseFromLibrary: '从相册选择',
         pasteFromClipboard: '从剪贴板粘贴',
+        dropImagesToAttach: '松开以添加图片',
         sharing: {
             title: '共享',
             directSharing: '直接共享',

--- a/packages/happy-app/sources/text/translations/zh-Hant.ts
+++ b/packages/happy-app/sources/text/translations/zh-Hant.ts
@@ -763,6 +763,7 @@ export const zhHant: TranslationStructure = {
         takePhoto: '拍照',
         chooseFromLibrary: '從圖庫選擇',
         pasteFromClipboard: '從剪貼簿貼上',
+        dropImagesToAttach: '放開以加入圖片',
         sharing: {
             title: '共享',
             directSharing: '直接共享',

--- a/packages/happy-app/src-tauri/tauri.conf.json
+++ b/packages/happy-app/src-tauri/tauri.conf.json
@@ -25,6 +25,7 @@
         "decorations": true,
         "titleBarStyle": "Overlay",
         "hiddenTitle": true,
+        "dragDropEnabled": false,
         "backgroundThrottling": "disabled"
       }
     ],

--- a/packages/happy-app/src-tauri/tauri.preview.conf.json
+++ b/packages/happy-app/src-tauri/tauri.preview.conf.json
@@ -5,7 +5,8 @@
   "app": {
     "windows": [
       {
-        "title": "Happy Next (preview)"
+        "title": "Happy Next (preview)",
+        "dragDropEnabled": false
       }
     ],
     "security": {


### PR DESCRIPTION
## Summary

Allow desktop users to drop images anywhere in the active session window to attach them to a message.

## Changes

- Listen for window-wide image drag and drop events in the focused session.
- Show a localized drop overlay while dragging supported files.
- Respect image support and the four-image attachment limit.
- Disable Tauri native drag and drop so web drag events receive dropped files.

## Testing

- [x] Tested locally
- [x] Existing tests pass (`yarn typecheck` in `packages/happy-app`)
- [ ] New tests added (not applicable)

## Related issues

None.