### PR TITLE
feat(cli): support resuming Codex sessions

### DIFF
--- a/packages/happy-cli/src/codex/__tests__/emitReadyIfIdle.test.ts
+++ b/packages/happy-cli/src/codex/__tests__/emitReadyIfIdle.test.ts
@@ -1,5 +1,24 @@
 import { describe, expect, it, vi } from 'vitest';
-import { emitReadyIfIdle } from '../runCodex';
+import { emitReadyIfIdle, formatCodexProcessExitMessage } from '../runCodex';
+
+describe('formatCodexProcessExitMessage', () => {
+    it('explains how to resolve an active writer conflict', () => {
+        const message = formatCodexProcessExitMessage(new Error(
+            "Codex 'thread/resume' request failed: thread session-123 already has an active writer (code -32600)",
+        ));
+
+        expect(message).toContain('Cannot resume this Codex session');
+        expect(message).toContain('Exit the original Codex or Happy session, then try again.');
+        expect(message).toContain("Codex error: Codex 'thread/resume' request failed");
+        expect(message).not.toContain('Error: Codex');
+    });
+
+    it('preserves the existing message for other process failures', () => {
+        expect(formatCodexProcessExitMessage('connection closed')).toBe(
+            'Process exited unexpectedly: connection closed',
+        );
+    });
+});
 
 describe('emitReadyIfIdle', () => {
     it('emits ready and notification when queue is idle', () => {

--- a/packages/happy-cli/src/codex/appserver/CodexJsonRpcPeer.test.ts
+++ b/packages/happy-cli/src/codex/appserver/CodexJsonRpcPeer.test.ts
@@ -1,0 +1,71 @@
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { CodexJsonRpcPeer } from './CodexJsonRpcPeer';
+
+function processExists(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code !== 'ESRCH';
+  }
+}
+
+async function waitFor<T>(read: () => Promise<T | null>, timeoutMs = 2_000): Promise<T> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const value = await read();
+    if (value !== null) return value;
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+  throw new Error(`Condition was not met within ${timeoutMs}ms`);
+}
+
+describe.skipIf(process.platform === 'win32')('CodexJsonRpcPeer process cleanup', () => {
+  let processGroupId: number | null = null;
+  let tempDir: string | null = null;
+
+  afterEach(async () => {
+    if (processGroupId && processExists(processGroupId)) {
+      try { process.kill(-processGroupId, 'SIGKILL'); } catch { /* already exited */ }
+    }
+    if (tempDir) await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('kills the detached process group without leaving its child behind', async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'happy-codex-peer-'));
+    const childPidFile = join(tempDir, 'child.pid');
+    const peer = new CodexJsonRpcPeer();
+
+    await peer.spawn('/bin/sh', [
+      '-c',
+      'sleep 60 & echo $! > "$1"; wait',
+      'codex-test',
+      childPidFile,
+    ], { cwd: tempDir });
+
+    processGroupId = (peer as unknown as { process: { pid?: number } }).process.pid ?? null;
+    expect(processGroupId).not.toBeNull();
+
+    const childPid = await waitFor(async () => {
+      try {
+        const value = Number.parseInt(await readFile(childPidFile, 'utf8'), 10);
+        return Number.isFinite(value) ? value : null;
+      } catch {
+        return null;
+      }
+    });
+    expect(processExists(processGroupId!)).toBe(true);
+    expect(processExists(childPid)).toBe(true);
+
+    await peer.close();
+
+    await waitFor(async () => (
+      !processExists(processGroupId!) && !processExists(childPid) ? true : null
+    ));
+    expect(processExists(processGroupId!)).toBe(false);
+    expect(processExists(childPid)).toBe(false);
+  });
+});

--- a/packages/happy-cli/src/codex/cli.test.ts
+++ b/packages/happy-cli/src/codex/cli.test.ts
@@ -1,0 +1,204 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  CodexCliUsageError,
+  parseCodexCliInvocation,
+  resolveCodexResumeFile,
+} from './cli';
+
+describe('parseCodexCliInvocation', () => {
+  it('starts a new session when no Codex arguments are provided', () => {
+    expect(parseCodexCliInvocation([])).toEqual({ kind: 'start', startedBy: undefined });
+  });
+
+  it('parses resume using the current directory by default', () => {
+    expect(parseCodexCliInvocation(['resume'])).toEqual({
+      kind: 'resume',
+      startedBy: undefined,
+      sessionId: undefined,
+      includeAllDirectories: false,
+      selectMostRecent: false,
+    });
+  });
+
+  it('parses resume flags, session IDs, and Happy internal options', () => {
+    expect(parseCodexCliInvocation([
+      'resume',
+      '--all',
+      '--last',
+      '--happy-starting-mode',
+      'remote',
+      '--started-by',
+      'daemon',
+    ])).toEqual({
+      kind: 'resume',
+      startedBy: 'daemon',
+      sessionId: undefined,
+      includeAllDirectories: true,
+      selectMostRecent: true,
+    });
+    expect(parseCodexCliInvocation(['--started-by', 'terminal', 'resume', 'session-123'])).toEqual({
+      kind: 'resume',
+      startedBy: 'terminal',
+      sessionId: 'session-123',
+      includeAllDirectories: false,
+      selectMostRecent: false,
+    });
+  });
+
+  it('returns help without starting a session', () => {
+    expect(parseCodexCliInvocation(['--help'])).toEqual({ kind: 'help' });
+    expect(parseCodexCliInvocation(['resume', '--help'])).toEqual({ kind: 'help' });
+  });
+
+  it('rejects unsupported commands and invalid resume combinations', () => {
+    expect(() => parseCodexCliInvocation(['fork'])).toThrow(CodexCliUsageError);
+    expect(() => parseCodexCliInvocation(['resume', '--unknown'])).toThrow(
+      'Unsupported option for happy codex resume: --unknown',
+    );
+    expect(() => parseCodexCliInvocation(['resume', '--last', 'session-123'])).toThrow(
+      '--last cannot be used together with a session ID.',
+    );
+    expect(() => parseCodexCliInvocation(['--started-by', 'other'])).toThrow(
+      '--started-by must be followed by "daemon" or "terminal".',
+    );
+    expect(() => parseCodexCliInvocation(['--happy-starting-mode', 'other'])).toThrow(
+      '--happy-starting-mode must be followed by "local" or "remote".',
+    );
+  });
+});
+
+describe('resolveCodexResumeFile', () => {
+  it('resolves an explicitly selected session', async () => {
+    const findSessionFile = vi.fn(() => '/sessions/selected.jsonl');
+    const listSessions = vi.fn();
+
+    await expect(resolveCodexResumeFile(
+      {
+        kind: 'resume',
+        sessionId: 'session-123',
+        includeAllDirectories: false,
+        selectMostRecent: false,
+      },
+      '/repo',
+      { findSessionFile, listSessions },
+    )).resolves.toBe('/sessions/selected.jsonl');
+
+    expect(findSessionFile).toHaveBeenCalledWith('session-123');
+    expect(listSessions).not.toHaveBeenCalled();
+  });
+
+  it('selects the newest session from the current directory with --last', async () => {
+    const findSessionFile = vi.fn();
+    const listSessions = vi.fn(async () => [
+      { sessionId: 'same-id', sessionFile: '/sessions/repo-older.jsonl', originalPath: '/repo', updatedAt: 1 },
+      { sessionId: 'same-id', sessionFile: '/sessions/other-newest.jsonl', originalPath: '/other', updatedAt: 3 },
+      { sessionId: 'same-id', sessionFile: '/sessions/repo-newest.jsonl', originalPath: '/repo', updatedAt: 2 },
+    ]);
+
+    await expect(resolveCodexResumeFile(
+      { kind: 'resume', includeAllDirectories: false, selectMostRecent: true },
+      '/repo',
+      { findSessionFile, listSessions },
+    )).resolves.toBe('/sessions/repo-newest.jsonl');
+    expect(findSessionFile).not.toHaveBeenCalled();
+  });
+
+  it('selects the newest session from any directory with --last --all', async () => {
+    const findSessionFile = vi.fn((id: string) => `/sessions/${id}.jsonl`);
+    const listSessions = vi.fn(async () => [
+      { sessionId: 'older', sessionFile: '/sessions/older.jsonl', originalPath: '/repo', updatedAt: 1 },
+      { sessionId: 'newest', sessionFile: '/sessions/newest.jsonl', originalPath: '/other', updatedAt: 2 },
+    ]);
+
+    await expect(resolveCodexResumeFile(
+      { kind: 'resume', includeAllDirectories: true, selectMostRecent: true },
+      '/repo',
+      { findSessionFile, listSessions },
+    )).resolves.toBe('/sessions/newest.jsonl');
+  });
+
+  it('fails clearly instead of silently creating a new session', async () => {
+    await expect(resolveCodexResumeFile(
+      { kind: 'resume', includeAllDirectories: false, selectMostRecent: false },
+      '/repo',
+      { findSessionFile: vi.fn(), listSessions: vi.fn(async () => []) },
+    )).rejects.toThrow('No resumable Codex session found for /repo.');
+  });
+
+  it('opens a picker for resume without --last', async () => {
+    const selectSession = vi.fn(async (sessions: readonly any[]) => sessions[1]);
+    const listSessions = vi.fn(async () => [
+      { sessionId: 'older', sessionFile: '/sessions/older.jsonl', originalPath: '/repo', updatedAt: 1 },
+      { sessionId: 'newest', sessionFile: '/sessions/newest.jsonl', originalPath: '/repo', updatedAt: 2 },
+      { sessionId: 'other', sessionFile: '/sessions/other.jsonl', originalPath: '/other', updatedAt: 3 },
+    ]);
+
+    await expect(resolveCodexResumeFile(
+      { kind: 'resume', includeAllDirectories: false, selectMostRecent: false },
+      '/repo',
+      {
+        findSessionFile: vi.fn(),
+        listSessions,
+        isInteractive: () => true,
+        selectSession,
+      },
+    )).resolves.toBe('/sessions/older.jsonl');
+
+    expect(selectSession).toHaveBeenCalledWith([
+      expect.objectContaining({ sessionId: 'newest' }),
+      expect.objectContaining({ sessionId: 'older' }),
+    ]);
+  });
+
+  it('includes sessions from every directory in the picker with --all', async () => {
+    const selectSession = vi.fn(async (sessions: readonly any[]) => sessions[0]);
+
+    await resolveCodexResumeFile(
+      { kind: 'resume', includeAllDirectories: true, selectMostRecent: false },
+      '/repo',
+      {
+        findSessionFile: vi.fn(),
+        listSessions: vi.fn(async () => [
+          { sessionId: 'other', sessionFile: '/sessions/other.jsonl', originalPath: '/other', updatedAt: 2 },
+          { sessionId: 'repo', sessionFile: '/sessions/repo.jsonl', originalPath: '/repo', updatedAt: 1 },
+        ]),
+        isInteractive: () => true,
+        selectSession,
+      },
+    );
+
+    expect(selectSession).toHaveBeenCalledWith([
+      expect.objectContaining({ sessionId: 'other' }),
+      expect.objectContaining({ sessionId: 'repo' }),
+    ]);
+  });
+
+  it('requires --last or a session ID without an interactive terminal', async () => {
+    await expect(resolveCodexResumeFile(
+      { kind: 'resume', includeAllDirectories: false, selectMostRecent: false },
+      '/repo',
+      {
+        findSessionFile: vi.fn(),
+        listSessions: vi.fn(async () => [
+          { sessionId: 'session-123', sessionFile: '/sessions/session.jsonl', originalPath: '/repo' },
+        ]),
+        isInteractive: () => false,
+      },
+    )).rejects.toThrow('Use `happy codex resume --last`');
+  });
+
+  it('ends cleanly when picker selection is cancelled', async () => {
+    await expect(resolveCodexResumeFile(
+      { kind: 'resume', includeAllDirectories: false, selectMostRecent: false },
+      '/repo',
+      {
+        findSessionFile: vi.fn(),
+        listSessions: vi.fn(async () => [
+          { sessionId: 'session-123', sessionFile: '/sessions/session.jsonl', originalPath: '/repo' },
+        ]),
+        isInteractive: () => true,
+        selectSession: vi.fn(async () => null),
+      },
+    )).rejects.toMatchObject({ name: 'CodexCliSelectionCancelledError' });
+  });
+});

--- a/packages/happy-cli/src/codex/cli.ts
+++ b/packages/happy-cli/src/codex/cli.ts
@@ -1,0 +1,209 @@
+import { resolve } from 'node:path';
+import { findCodexSessionFile, listCodexSessions } from './utils/codexSessionReader';
+
+export type CodexCliInvocation =
+  | {
+      kind: 'start';
+      startedBy?: 'daemon' | 'terminal';
+    }
+  | {
+      kind: 'resume';
+      startedBy?: 'daemon' | 'terminal';
+      sessionId?: string;
+      includeAllDirectories: boolean;
+      selectMostRecent: boolean;
+      resumeCwd?: 'session' | 'current' | 'ask';
+    }
+  | {
+      kind: 'help';
+    };
+
+export class CodexCliUsageError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'CodexCliUsageError';
+  }
+}
+
+export class CodexCliSelectionCancelledError extends Error {
+  constructor() {
+    super('Codex session selection cancelled.');
+    this.name = 'CodexCliSelectionCancelledError';
+  }
+}
+
+export function parseCodexCliInvocation(args: readonly string[]): CodexCliInvocation {
+  const remaining: string[] = [];
+  let startedBy: 'daemon' | 'terminal' | undefined;
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === '--happy-starting-mode') {
+      const value = args[++i];
+      if (value !== 'local' && value !== 'remote') {
+        throw new CodexCliUsageError('--happy-starting-mode must be followed by "local" or "remote".');
+      }
+      continue;
+    }
+    if (arg !== '--started-by') {
+      remaining.push(arg);
+      continue;
+    }
+
+    const value = args[++i];
+    if (value !== 'daemon' && value !== 'terminal') {
+      throw new CodexCliUsageError('--started-by must be followed by "daemon" or "terminal".');
+    }
+    startedBy = value;
+  }
+
+  if (remaining.length === 0) {
+    return { kind: 'start', startedBy };
+  }
+
+  if (remaining.length === 1 && (remaining[0] === '--help' || remaining[0] === '-h')) {
+    return { kind: 'help' };
+  }
+
+  const [command, ...commandArgs] = remaining;
+  if (command !== 'resume') {
+    throw new CodexCliUsageError(`Unsupported Codex command or option: ${command}`);
+  }
+  if (commandArgs.length === 1 && (commandArgs[0] === '--help' || commandArgs[0] === '-h')) {
+    return { kind: 'help' };
+  }
+
+  let sessionId: string | undefined;
+  let includeAllDirectories = false;
+  let hasLast = false;
+
+  let resumeCwd: 'session' | 'current' | 'ask' | undefined;
+  for (let i = 0; i < commandArgs.length; i++) {
+    const arg = commandArgs[i];
+    if (arg === '--resume-cwd') {
+      const value = commandArgs[++i];
+      if (value !== 'session' && value !== 'current' && value !== 'ask') {
+        throw new CodexCliUsageError('--resume-cwd must be followed by session, current, or ask.');
+      }
+      resumeCwd = value;
+    } else if (arg === '--all') {
+      includeAllDirectories = true;
+    } else if (arg === '--last') {
+      hasLast = true;
+    } else if (arg.startsWith('-')) {
+      throw new CodexCliUsageError(`Unsupported option for happy codex resume: ${arg}`);
+    } else if (sessionId) {
+      throw new CodexCliUsageError('happy codex resume accepts at most one session ID.');
+    } else {
+      sessionId = arg;
+    }
+  }
+
+  if (hasLast && sessionId) {
+    throw new CodexCliUsageError('--last cannot be used together with a session ID.');
+  }
+
+  return {
+    kind: 'resume',
+    startedBy,
+    sessionId,
+    includeAllDirectories,
+    selectMostRecent: hasLast,
+    ...(resumeCwd ? { resumeCwd } : {}),
+  };
+}
+
+export type ResumeSession = {
+  sessionId: string;
+  sessionFile: string;
+  originalPath: string | null;
+  title?: string | null;
+  updatedAt?: number;
+};
+
+type ResumeResolverDependencies = {
+  findSessionFile: (sessionId: string) => string | null;
+  listSessions: () => Promise<ResumeSession[]>;
+  isInteractive?: () => boolean;
+  selectSession?: (sessions: readonly ResumeSession[]) => Promise<ResumeSession | null>;
+};
+
+async function promptForCodexSession(sessions: readonly ResumeSession[]): Promise<ResumeSession | null> {
+  const { selectCodexSession } = await import('./sessionPicker');
+  return selectCodexSession(sessions);
+}
+
+const defaultResumeResolverDependencies: ResumeResolverDependencies = {
+  findSessionFile: findCodexSessionFile,
+  listSessions: listCodexSessions,
+  isInteractive: () => Boolean(process.stdin.isTTY && process.stdout.isTTY),
+  selectSession: promptForCodexSession,
+};
+
+export async function resolveCodexResumeFile(
+  invocation: Extract<CodexCliInvocation, { kind: 'resume' }>,
+  workingDirectory: string = process.cwd(),
+  dependencies: ResumeResolverDependencies = defaultResumeResolverDependencies,
+): Promise<string> {
+  if (invocation.sessionId) {
+    const sessionFile = dependencies.findSessionFile(invocation.sessionId);
+    if (!sessionFile) {
+      throw new CodexCliUsageError(`Codex session not found: ${invocation.sessionId}`);
+    }
+    return sessionFile;
+  }
+
+  const normalizedWorkingDirectory = resolve(workingDirectory);
+  const sessions = await dependencies.listSessions();
+  // Scope the list by session metadata, not the latest turn_context.cwd.
+  // Choosing the working directory after selection is handled by resumeDirectory.ts.
+  const matchingSessions = sessions
+    .filter(candidate => (
+      invocation.includeAllDirectories
+      || (candidate.originalPath !== null && resolve(candidate.originalPath) === normalizedWorkingDirectory)
+    ))
+    .sort((a, b) => (b.updatedAt ?? 0) - (a.updatedAt ?? 0));
+
+  if (matchingSessions.length === 0) {
+    const scope = invocation.includeAllDirectories
+      ? 'in any directory'
+      : `for ${normalizedWorkingDirectory}`;
+    const hint = invocation.includeAllDirectories ? '' : ' Try `happy codex resume --all`.';
+    throw new CodexCliUsageError(`No resumable Codex session found ${scope}.${hint}`);
+  }
+
+  if (invocation.selectMostRecent) {
+    return matchingSessions[0].sessionFile;
+  }
+
+  const isInteractive = dependencies.isInteractive ?? defaultResumeResolverDependencies.isInteractive!;
+  if (!isInteractive()) {
+    throw new CodexCliUsageError(
+      'Cannot open the Codex session picker without an interactive terminal. '
+      + 'Use `happy codex resume --last` or `happy codex resume <SESSION_ID>`.',
+    );
+  }
+
+  const selectSession = dependencies.selectSession ?? defaultResumeResolverDependencies.selectSession!;
+  const selectedSession = await selectSession(matchingSessions);
+  if (!selectedSession) {
+    throw new CodexCliSelectionCancelledError();
+  }
+  return selectedSession.sessionFile;
+}
+
+export const CODEX_CLI_HELP = `happy codex - Start Codex with Happy remote control
+
+Usage:
+  happy codex                       Start a new Codex session
+  happy codex resume                Select a session from the current directory
+  happy codex resume --last         Resume the latest session in the current directory
+  happy codex resume <SESSION_ID>   Resume a specific session
+  happy codex resume --all          Select a session from any directory
+
+Options:
+  --last                            Resume the most recent session without a picker
+  --all                             Include sessions outside the current directory
+  --resume-cwd <session|current|ask> Choose resume directory; ask overrides saved preference
+  --started-by <daemon|terminal>    Set how the Happy session was started
+  -h, --help                        Show this help`;

--- a/packages/happy-cli/src/codex/resumeDirectory.test.ts
+++ b/packages/happy-cli/src/codex/resumeDirectory.test.ts
@@ -1,0 +1,105 @@
+import { mkdtemp, writeFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it, vi } from 'vitest';
+import { readCodexResumeDirectory, resolveCodexResumeDirectory } from './resumeDirectory';
+import { parseCodexCliInvocation } from './cli';
+const current = join(tmpdir(), 'current');
+const session = join(tmpdir(), 'session');
+function dependencies() {
+  return {
+    readDirectory: vi.fn(async () => session as string | null),
+    readPreference: vi.fn(async (): Promise<'session' | 'current' | undefined> => undefined),
+    savePreference: vi.fn(async (_mode: 'session' | 'current') => {}),
+    isInteractive: () => true,
+    prompt: vi.fn(async (): Promise<{ mode: 'session' | 'current'; remember: boolean } | null> => ({ mode: 'session', remember: false })),
+    normalize: vi.fn(async (path: string) => path),
+    validate: vi.fn(async (_path: string) => {}),
+  };
+}
+describe('Codex resume directory', () => {
+  it('reads latest turn_context cwd and handles malformed or missing metadata', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'happy-resume-cwd-'));
+    try {
+      const file = join(dir, 'rollout.jsonl');
+      const record = (type: string, cwd: string) => JSON.stringify({ type, payload: { cwd } });
+      await writeFile(file, [record('session_meta', current), record('turn_context', session), 'broken JSON', record('session_meta', current), record('turn_context', 'relative'), 'null'].join('\n'));
+      expect(await readCodexResumeDirectory(file)).toBe(session);
+      await writeFile(file, record('session_meta', current));
+      expect(await readCodexResumeDirectory(file)).toBe(current);
+      await writeFile(file, '');
+      expect(await readCodexResumeDirectory(file)).toBeNull();
+      await expect(readCodexResumeDirectory(join(dir, 'missing'))).rejects.toThrow();
+    } finally { await rm(dir, { recursive: true, force: true }); }
+  });
+  it.each(['session', 'current'] as const)('honors one-time %s selection', async mode => {
+    const deps = dependencies();
+    deps.prompt.mockResolvedValue({ mode, remember: false });
+    expect(await resolveCodexResumeDirectory('file', current, undefined, deps)).toBe(mode === 'session' ? session : current);
+    expect(deps.prompt).toHaveBeenCalledWith(session, current);
+    expect(deps.savePreference).not.toHaveBeenCalled();
+  });
+  it.each(['session', 'current'] as const)('saves always-%s selection', async mode => {
+    const deps = dependencies();
+    deps.prompt.mockResolvedValue({ mode, remember: true });
+    await resolveCodexResumeDirectory('file', current, undefined, deps);
+    expect(deps.savePreference).toHaveBeenCalledWith(mode);
+  });
+  it.each(['session', 'current'] as const)('honors saved %s preference', async mode => {
+    const deps = dependencies();
+    deps.readPreference.mockResolvedValue(mode);
+    expect(await resolveCodexResumeDirectory('file', current, undefined, deps)).toBe(mode === 'session' ? session : current);
+    expect(deps.prompt).not.toHaveBeenCalled();
+  });
+  it('explicit current overrides saved session preference without changing it', async () => {
+    const deps = dependencies();
+    deps.readPreference.mockResolvedValue('session');
+    expect(await resolveCodexResumeDirectory('file', current, 'current', deps)).toBe(current);
+    expect(deps.readDirectory).not.toHaveBeenCalled();
+    expect(deps.savePreference).not.toHaveBeenCalled();
+  });
+  it('ask overrides saved preference', async () => {
+    const deps = dependencies();
+    deps.readPreference.mockResolvedValue('current');
+    await resolveCodexResumeDirectory('file', current, 'ask', deps);
+    expect(deps.prompt).toHaveBeenCalled();
+  });
+  it('does not prompt for equivalent paths including symlink aliases', async () => {
+    const deps = dependencies();
+    deps.normalize.mockResolvedValue(session);
+    await resolveCodexResumeDirectory('file', current, undefined, deps);
+    expect(deps.prompt).not.toHaveBeenCalled();
+  });
+  it('requires explicit intent in non-interactive mode', async () => {
+    const deps = dependencies();
+    deps.isInteractive = () => false;
+    await expect(resolveCodexResumeDirectory('file', current, undefined, deps)).rejects.toThrow('--resume-cwd');
+    expect(await resolveCodexResumeDirectory('file', current, 'session', deps)).toBe(session);
+    expect(await resolveCodexResumeDirectory('file', current, 'current', deps)).toBe(current);
+  });
+  it('cancels without saving', async () => {
+    const deps = dependencies();
+    deps.prompt.mockResolvedValue(null);
+    await expect(resolveCodexResumeDirectory('file', current, undefined, deps)).rejects.toMatchObject({ name: 'CodexCliSelectionCancelledError' });
+    expect(deps.savePreference).not.toHaveBeenCalled();
+  });
+  it('does not save preference or silently fall back for missing chosen directory', async () => {
+    const deps = dependencies();
+    deps.prompt.mockResolvedValue({ mode: 'session', remember: true });
+    deps.validate.mockRejectedValue(new Error('missing'));
+    await expect(resolveCodexResumeDirectory('file', current, undefined, deps)).rejects.toThrow('Cannot use resume working directory');
+    expect(deps.savePreference).not.toHaveBeenCalled();
+  });
+  it('uses current cwd for missing metadata unless session cwd is required', async () => {
+    const deps = dependencies();
+    deps.readDirectory.mockResolvedValue(null);
+    expect(await resolveCodexResumeDirectory('file', current, undefined, deps)).toBe(current);
+    await expect(resolveCodexResumeDirectory('file', current, 'session', deps)).rejects.toThrow('No working directory');
+  });
+  it.each(['session', 'current', 'ask'])('parses --resume-cwd %s', mode => {
+    expect(parseCodexCliInvocation(['resume', '--resume-cwd', mode, 'id', '--all'])).toMatchObject({ sessionId: 'id', resumeCwd: mode, includeAllDirectories: true });
+  });
+  it.each([{ values: [] }, { values: ['wrong'] }])('rejects invalid option $values', ({ values }) => {
+    expect(() => parseCodexCliInvocation(['resume', '--resume-cwd', ...values])).toThrow('--resume-cwd must be followed');
+  });
+});

--- a/packages/happy-cli/src/codex/resumeDirectory.ts
+++ b/packages/happy-cli/src/codex/resumeDirectory.ts
@@ -1,0 +1,114 @@
+import { constants, createReadStream } from 'node:fs';
+import { access, realpath, stat } from 'node:fs/promises';
+import { isAbsolute, resolve } from 'node:path';
+import { createInterface as createLineReader } from 'node:readline';
+import { createInterface } from 'node:readline/promises';
+import { readSettings, updateSettings } from '@/persistence';
+import { CodexCliSelectionCancelledError, CodexCliUsageError } from './cli';
+
+type DirectoryMode = 'session' | 'current';
+type DirectoryChoice = { mode: DirectoryMode; remember: boolean };
+
+// A session can have changed directories since its initial session_meta record.
+export async function readCodexResumeDirectory(file: string): Promise<string | null> {
+  const stream = createReadStream(file, { encoding: 'utf8' });
+  const lines = createLineReader({ input: stream, crlfDelay: Infinity });
+  let directory: string | null = null;
+  try {
+    for await (const line of lines) {
+      let record;
+      try { record = JSON.parse(line); } catch { continue; }
+      const cwd = record?.payload?.cwd;
+      if (typeof cwd !== 'string' || !isAbsolute(cwd)) continue;
+      if (record.type === 'turn_context' || (record.type === 'session_meta' && !directory)) {
+        directory = cwd;
+      }
+    }
+  } finally {
+    lines.close();
+    stream.destroy();
+  }
+  return directory;
+}
+
+const safeText = (text: string) => text.replace(/[\x00-\x1f\x7f-\x9f]/g, ' ');
+
+async function promptDirectory(session: string, current: string): Promise<DirectoryChoice | null> {
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  try {
+    console.log('\nChoose working directory to resume this session\n');
+    console.log('  Session = latest cwd recorded in the resumed session');
+    console.log('  Current = your current working directory\n');
+    console.log(`  1. Use session directory (${safeText(session)})`);
+    console.log(`  2. Use current directory (${safeText(current)})`);
+    console.log('  3. Always use session directory');
+    console.log('  4. Always use current directory');
+    console.log('\n  Saved preferences apply only to Happy. Use --resume-cwd ask to choose again.');
+    while (true) {
+      const answer = (await rl.question('Enter a number, or q to cancel: ')).trim();
+      if (answer.toLowerCase() === 'q') return null;
+      if (['1', '2', '3', '4'].includes(answer)) {
+        return { mode: answer === '1' || answer === '3' ? 'session' : 'current', remember: Number(answer) >= 3 };
+      }
+      console.log('Enter a number from 1 to 4, or q to cancel.');
+    }
+  } finally {
+    rl.close();
+  }
+}
+
+const defaultDependencies = {
+  readDirectory: readCodexResumeDirectory,
+  readPreference: async (): Promise<DirectoryMode | undefined> => {
+    const preference = (await readSettings()).codexResumeCwd;
+    return preference === 'session' || preference === 'current' ? preference : undefined;
+  },
+  savePreference: async (mode: DirectoryMode) => {
+    await updateSettings(settings => ({ ...settings, codexResumeCwd: mode }));
+  },
+  isInteractive: () => Boolean(process.stdin.isTTY && process.stdout.isTTY),
+  prompt: promptDirectory,
+  normalize: async (directory: string) => realpath(directory).catch(() => resolve(directory)),
+  validate: async (directory: string) => {
+    if (!(await stat(directory)).isDirectory()) throw new Error('Not a directory');
+    await access(directory, constants.X_OK);
+  },
+};
+
+export async function resolveCodexResumeDirectory(
+  file: string,
+  currentDirectory: string,
+  override?: DirectoryMode | 'ask',
+  dependencies = defaultDependencies,
+): Promise<string> {
+  const current = resolve(currentDirectory);
+  const mode = override ?? await dependencies.readPreference();
+  let choice: DirectoryChoice = { mode: 'current', remember: false };
+  let session: string | null = null;
+  if (mode !== 'current') {
+    session = await dependencies.readDirectory(file);
+    if (!session && mode === 'session') {
+      throw new CodexCliUsageError('No working directory recorded in this session. Use --resume-cwd current.');
+    }
+    if (session) {
+      if (mode === 'session' || await dependencies.normalize(session) === await dependencies.normalize(current)) {
+        choice = { mode: 'session', remember: false };
+      } else {
+        if (!dependencies.isInteractive()) {
+          throw new CodexCliUsageError('Resume directory differs from current directory. Use --resume-cwd session or --resume-cwd current in non-interactive mode.');
+        }
+        const selected = await dependencies.prompt(session, current);
+        if (!selected) throw new CodexCliSelectionCancelledError();
+        choice = selected;
+      }
+    }
+  }
+  const directory = choice.mode === 'session' ? session! : current;
+  try {
+    await dependencies.validate(directory);
+  } catch {
+    throw new CodexCliUsageError(`Cannot use resume working directory: ${safeText(directory)}. Check that it exists and is accessible, or use --resume-cwd current.`);
+  }
+  if (choice.remember) await dependencies.savePreference(choice.mode);
+  return directory;
+}

--- a/packages/happy-cli/src/codex/runCodex.ts
+++ b/packages/happy-cli/src/codex/runCodex.ts
@@ -44,6 +44,7 @@ import type { AgentMessage } from '@/agent/core';
 import { handleConfigMetadataEvent } from '@/agent/acp/sessionUpdateHandlers';
 import { findCodexSessionFile } from './utils/codexSessionReader';
 import { summarizeBashToolOutput } from '@/modules/common/loadableToolOutput';
+import { cleanupStdinAfterInk } from '@/utils/terminalStdinCleanup';
 
 type ReadyEventOptions = {
     pending: unknown;
@@ -95,6 +96,22 @@ function formatUnknownCodexError(error: unknown): string {
     }
 }
 
+export function formatCodexProcessExitMessage(error: unknown): string {
+    const errorMessage = error instanceof Error
+        ? error.message
+        : (typeof error === 'string' ? error : null);
+
+    if (errorMessage?.includes('already has an active writer')) {
+        return [
+            'Cannot resume this Codex session because it is still running in another process.',
+            'Exit the original Codex or Happy session, then try again.',
+            `Codex error: ${errorMessage}`,
+        ].join('\n');
+    }
+
+    return `Process exited unexpectedly: ${formatUnknownCodexError(error)}`;
+}
+
 /**
  * Map Happy permission mode to Codex approval policy
  */
@@ -128,6 +145,7 @@ function mapSandbox(permissionMode: string): SandboxMode {
 export async function runCodex(opts: {
     credentials: Credentials;
     startedBy?: 'daemon' | 'terminal';
+    resumeFile?: string;
 }): Promise<void> {
     // Use shared PermissionMode type for cross-agent compatibility
     interface EnhancedMode {
@@ -149,7 +167,7 @@ export async function runCodex(opts: {
     const api = await ApiClient.create(opts.credentials);
 
     // Log startup options
-    logger.debug(`[codex] Starting with options: startedBy=${opts.startedBy || 'terminal'}`);
+    logger.debug(`[codex] Starting with options: startedBy=${opts.startedBy || 'terminal'}, resume=${opts.resumeFile ? 'yes' : 'no'}`);
 
     //
     // Machine
@@ -440,8 +458,8 @@ export async function runCodex(opts: {
     let abortFeedbackSent = false;
     let storedSessionIdForResume: string | null = null;
 
-    // Resume file from App-side resume/duplicate (passed via daemon env var)
-    const envResumeFile = process.env.HAPPY_CODEX_RESUME_FILE || null;
+    // Resume file from the CLI or App-side resume/duplicate (passed via daemon env var)
+    const initialResumeFile = opts.resumeFile || process.env.HAPPY_CODEX_RESUME_FILE || null;
     // Current backend instance (re-created on mode change)
     // Typed as any to prevent TS narrowing issues (assigned inside createBackend())
     let backend: any = null;
@@ -510,7 +528,58 @@ export async function runCodex(opts: {
         clearInterval(keepAliveInterval);
         messageQueue.reset();
 
+        // Restore the terminal before any asynchronous cleanup. If a backend
+        // or network close stalls, leaving Ink mounted keeps the shell in raw
+        // mode and the user sees an indefinitely frozen exit screen.
+        if (inkInstance) {
+            inkInstance.unmount();
+            inkInstance = null;
+        }
+        await cleanupStdinAfterInk({
+            stdin: process.stdin,
+            drainMs: 0,
+            leaveRawMode: false,
+        });
+
+        const forcedExitTimer = setTimeout(() => {
+            logger.debug('[Codex] Timed out during session termination, forcing exit');
+            process.exit(0);
+        }, 12_000);
+
+        const runCleanupStep = async (
+            label: string,
+            cleanup: () => Promise<unknown>,
+            timeoutMs: number,
+        ): Promise<void> => {
+            let timeout: ReturnType<typeof setTimeout> | undefined;
+            try {
+                await Promise.race([
+                    cleanup(),
+                    new Promise<never>((_, reject) => {
+                        timeout = setTimeout(
+                            () => reject(new Error(`${label} timed out after ${timeoutMs}ms`)),
+                            timeoutMs,
+                        );
+                    }),
+                ]);
+            } catch (error) {
+                logger.debug(`[Codex] ${label} failed during termination`, error);
+            } finally {
+                if (timeout) clearTimeout(timeout);
+            }
+        };
+
         try {
+            // Kill the Codex process group before doing any network cleanup.
+            // This ensures a stalled flush cannot leave app-server orphaned
+            // when the forced-exit watchdog fires.
+            await handleAbort();
+            await runCleanupStep('backend.dispose', async () => backend?.dispose(), 6_000);
+            backend = null;
+
+            stopCaffeinate();
+            mcp.stop();
+
             if (session) {
                 session.updateMetadata((currentMetadata) => ({
                     ...currentMetadata,
@@ -520,34 +589,20 @@ export async function runCodex(opts: {
                     archiveReason: 'User terminated'
                 }));
                 session.sendSessionDeath();
-                await session.flush();
-                await session.close();
+                await runCleanupStep('session.flush', () => session.flush(), 2_000);
+                await runCleanupStep('session.close', () => session.close(), 2_000);
             }
         } catch (error) {
             logger.debug('[Codex] Error while ending session during termination', error);
         }
 
         try {
-            await handleAbort();
-            logger.debug('[Codex] Abort completed, proceeding with backend disposal');
-        } catch (error) {
-            logger.debug('[Codex] Error during abort in termination flow', error);
-        }
-
-        try {
-            try {
-                await backend?.dispose();
-            } catch (e) {
-                logger.debug('[Codex] Error while disposing backend during termination', e);
-            }
-
-            stopCaffeinate();
-            mcp.stop();
-
             logger.debug('[Codex] Session termination complete, exiting');
+            clearTimeout(forcedExitTimer);
             process.exit(0);
         } catch (error) {
             logger.debug('[Codex] Error during session termination:', error);
+            clearTimeout(forcedExitTimer);
             process.exit(1);
         }
     };
@@ -571,8 +626,7 @@ export async function runCodex(opts: {
             logPath: isDebug() ? logger.getLogPath() : undefined,
             onExit: async () => {
                 logger.debug('[codex]: Exiting agent via Ctrl-C');
-                shouldExit = true;
-                await handleAbort();
+                await handleKillSession();
             }
         }), {
             exitOnCtrlC: false,
@@ -1049,7 +1103,9 @@ Tokens used: ${goal.tokensUsed}${goal.tokenBudget ? ` / ${goal.tokenBudget}` : '
 
     // Backfill history from previous session (if resuming/copying)
     // Awaited so that replace-mode batch completes before the main loop processes new messages
-    if (envResumeFile && ['1', 'true', 'yes'].includes(String(process.env.HAPPY_CODEX_BACKFILL).toLowerCase())) {
+    const shouldBackfillResume = !!opts.resumeFile
+        || ['1', 'true', 'yes'].includes(String(process.env.HAPPY_CODEX_BACKFILL).toLowerCase());
+    if (initialResumeFile && shouldBackfillResume) {
         try {
             // Wait briefly for socket connection to avoid dropping backfill messages
             for (let i = 0; i < 15 && !session.isConnected(); i++) {
@@ -1057,7 +1113,7 @@ Tokens used: ${goal.tokensUsed}${goal.tokenBudget ? ` / ${goal.tokenBudget}` : '
             }
             if (session.isConnected()) {
                 await backfillCodexSessionHistory({
-                    sessionIdOrPath: envResumeFile,
+                    sessionIdOrPath: initialResumeFile,
                     sendBatch: async (messages) => {
                         await session.sendBackfillBatch(messages, 'replace');
                     },
@@ -1174,8 +1230,8 @@ Tokens used: ${goal.tokensUsed}${goal.tokenBudget ? ` / ${goal.tokenBudget}` : '
                     if (nextResumeFile) {
                         commandResumeFile = nextResumeFile;
                         nextResumeFile = null;
-                    } else if (first && envResumeFile) {
-                        commandResumeFile = envResumeFile;
+                    } else if (first && initialResumeFile) {
+                        commandResumeFile = initialResumeFile;
                         messageBuffer.addMessage('Resuming from previous session...', 'status');
                     } else if (storedSessionIdForResume) {
                         commandResumeFile = findCodexResumeFile(storedSessionIdForResume);
@@ -1252,8 +1308,8 @@ Tokens used: ${goal.tokensUsed}${goal.tokenBudget ? ` / ${goal.tokenBudget}` : '
                         resumeFile = nextResumeFile;
                         nextResumeFile = null;
                         logger.debug('[Codex] Using resume file from mode change:', resumeFile);
-                    } else if (first && envResumeFile) {
-                        resumeFile = envResumeFile;
+                    } else if (first && initialResumeFile) {
+                        resumeFile = initialResumeFile;
                         logger.debug('[Codex] Using resume file from App-side resume:', resumeFile);
                         messageBuffer.addMessage('Resuming from previous session...', 'status');
                     } else if (storedSessionIdForResume) {
@@ -1333,6 +1389,7 @@ Tokens used: ${goal.tokensUsed}${goal.tokenBudget ? ` / ${goal.tokenBudget}` : '
                 }
             } catch (error) {
                 const errMsg = formatUnknownCodexError(error);
+                const processExitMessage = formatCodexProcessExitMessage(error);
                 logger.warn('Error in codex session:', errMsg);
                 const isAbortError = error instanceof Error && error.name === 'AbortError';
                 const isUserAbort = isAbortError || abortRequested;
@@ -1346,8 +1403,8 @@ Tokens used: ${goal.tokensUsed}${goal.tokenBudget ? ` / ${goal.tokenBudget}` : '
                         id: randomUUID(),
                     });
                 } else if (!isUserAbort) {
-                    messageBuffer.addMessage(`Process exited unexpectedly: ${errMsg}`, 'status');
-                    session.sendSessionEvent({ type: 'message', message: `Process exited unexpectedly: ${errMsg}` });
+                    messageBuffer.addMessage(processExitMessage, 'status');
+                    session.sendSessionEvent({ type: 'message', message: processExitMessage });
                     // Store session for potential recovery
                     if (backend && backend.isAlive) {
                         storedSessionIdForResume = backend.getSessionId();
@@ -1379,6 +1436,11 @@ Tokens used: ${goal.tokensUsed}${goal.tokenBudget ? ` / ${goal.tokenBudget}` : '
     } finally {
         logger.debug('[codex]: Final cleanup start');
         logActiveHandles('cleanup-start');
+
+        if (isTerminating) {
+            logger.debug('[codex]: Final cleanup is owned by the termination handler');
+            return;
+        }
 
         if (reconnectionHandle) {
             logger.debug('[codex]: Cancelling offline reconnection');

--- a/packages/happy-cli/src/codex/sessionPicker.test.ts
+++ b/packages/happy-cli/src/codex/sessionPicker.test.ts
@@ -1,0 +1,147 @@
+import React from 'react';
+import { PassThrough } from 'node:stream';
+import { render } from 'ink';
+import { CodexSessionPicker } from './sessionPicker';
+import { describe, expect, it, vi } from 'vitest';
+import { formatSessionAge, pickerPageSize, pickerWindow, sanitizeSessionPickerText } from './sessionPicker';
+
+describe('Codex session picker viewport', () => {
+  it('bounds rows by terminal height and a compact maximum', () => {
+    expect(pickerPageSize(40)).toBe(25);
+    expect(pickerPageSize(12)).toBe(6);
+    expect(pickerPageSize(6)).toBe(1);
+  });
+  it('renders only the first screen of a large list', () => {
+    expect(pickerWindow(500, 0, 0, 12)).toEqual({ selected: 0, start: 0, end: 12 });
+  });
+  it('scrolls only when moving outside the visible range', () => {
+    expect(pickerWindow(500, 11, 0, 12)).toEqual({ selected: 11, start: 0, end: 12 });
+    expect(pickerWindow(500, 12, 0, 12)).toEqual({ selected: 12, start: 1, end: 13 });
+    expect(pickerWindow(500, 8, 10, 12)).toEqual({ selected: 8, start: 8, end: 20 });
+  });
+  it('handles page moves and both list boundaries without wrapping', () => {
+    expect(pickerWindow(30, 24, 1, 12)).toEqual({ selected: 24, start: 13, end: 25 });
+    expect(pickerWindow(30, 200, 13, 12)).toEqual({ selected: 29, start: 18, end: 30 });
+    expect(pickerWindow(30, -12, 18, 12)).toEqual({ selected: 0, start: 0, end: 12 });
+  });
+  it('keeps the selected row visible after terminal resize', () => {
+    expect(pickerWindow(50, 11, 0, 4)).toEqual({ selected: 11, start: 8, end: 12 });
+    expect(pickerWindow(50, 49, 48, 12)).toEqual({ selected: 49, start: 38, end: 50 });
+  });
+  it('handles empty and short lists', () => {
+    expect(pickerWindow(0, 0, 0, 12)).toEqual({ selected: 0, start: 0, end: 0 });
+    expect(pickerWindow(1, 10, 0, 12)).toEqual({ selected: 0, start: 0, end: 1 });
+  });
+  it('strips terminal control characters without damaging Unicode titles', () => {
+    expect(sanitizeSessionPickerText('\x1b[31m你好👋\nnext\r\t\u009b\u2028end')).toBe('[31m你好👋 next    end');
+  });
+  it('formats relative timestamps and invalid dates', () => {
+    const now = 100 * 86400_000;
+    expect(formatSessionAge(undefined, now)).toBe('unknown');
+    expect(formatSessionAge(NaN, now)).toBe('unknown');
+    expect(formatSessionAge(now + 1000, now)).toBe('now');
+    expect(formatSessionAge(now - 120_000, now)).toBe('2m ago');
+    expect(formatSessionAge(now - 3600_000, now)).toBe('1h ago');
+    expect(formatSessionAge(now - 86400_000, now)).toBe('1d ago');
+  });
+});
+
+
+describe('Codex session picker keyboard interaction', () => {
+  function mount(rows = 11, count = 30) {
+    const input = Object.assign(new PassThrough(), {
+      isTTY: true, setRawMode: vi.fn(), ref: vi.fn(), unref: vi.fn(),
+    });
+    const output = Object.assign(new PassThrough(), { columns: 60, rows, isTTY: true });
+    let frame = '';
+    output.on('data', chunk => { frame += chunk.toString(); });
+    const sessions = Array.from({ length: count }, (_, index) => ({
+      sessionId: 'sameid', // Selection must use the actual record, not short ID.
+      sessionFile: `/sessions/${index}.jsonl`,
+      originalPath: `/repo/${index}`,
+      title: `Conversation-${index}`,
+    }));
+    const select = vi.fn();
+    const app = render(React.createElement(CodexSessionPicker, { sessions, onSelect: select }), {
+      stdin: input as unknown as NodeJS.ReadStream,
+      stdout: output as unknown as NodeJS.WriteStream,
+      debug: true, exitOnCtrlC: false, patchConsole: false,
+    });
+    return { input, output, select, app, text: () => frame, clear: () => { frame = ''; } };
+  }
+
+  it('limits rendering, handles arrows/pages/resize, and returns the exact selected file', async () => {
+    const view = mount();
+    try {
+      await vi.waitFor(() => expect(view.text()).toContain('Conversation-4'));
+      expect(view.text()).not.toContain('Conversation-5');
+      expect(view.text()).toContain('n/p page');
+      expect(view.text()).not.toContain('PgUp/PgDn');
+      view.input.write('\x1b[B');
+      await vi.waitFor(() => expect(view.text()).toContain('2 / 30'));
+      view.input.write('\x1b[6~');
+      await vi.waitFor(() => expect(view.text()).toContain('7 / 30'));
+      view.output.rows = 9;
+      view.output.emit('resize');
+      await vi.waitFor(() => expect(view.text()).toContain('Showing 6–8'));
+      view.input.write('\x1b[5~');
+      await vi.waitFor(() => expect(view.text()).toContain('4 / 30'));
+      view.input.write('\r');
+      await view.app.waitUntilExit();
+      expect(view.select).toHaveBeenCalledOnce();
+      expect(view.select.mock.calls[0][0].sessionFile).toBe('/sessions/3.jsonl');
+      expect(view.input.setRawMode).toHaveBeenLastCalledWith(false);
+    } finally { view.app.unmount(); view.app.cleanup(); view.input.destroy(); view.output.destroy(); }
+  });
+
+  it.each([
+    { next: '\x1b[6~', previous: '\x1b[5~' },
+    { next: 'n', previous: 'p' },
+  ])('moves an entire viewport using $next / $previous', async keys => {
+    const view = mount();
+    try {
+      await vi.waitFor(() => expect(view.text()).toContain('Showing 1–5'));
+      view.input.write(keys.next);
+      await vi.waitFor(() => expect(view.text()).toContain('Showing 6–10'));
+      view.input.write(keys.next);
+      await vi.waitFor(() => expect(view.text()).toContain('Showing 11–15'));
+      view.clear();
+      view.input.write(keys.previous);
+      await vi.waitFor(() => expect(view.text()).toContain('6 / 30 · Showing 6–10'));
+      view.input.write('\r');
+      await view.app.waitUntilExit();
+      expect(view.select.mock.calls[0][0].sessionFile).toBe('/sessions/5.jsonl');
+    } finally { view.app.unmount(); view.app.cleanup(); view.input.destroy(); view.output.destroy(); }
+  });
+
+  it('caps tall terminals at 25 rows and uses the resized viewport for paging', async () => {
+    const view = mount(50, 60);
+    try {
+      await vi.waitFor(() => expect(view.text()).toContain('Showing 1–25'));
+      expect(view.text()).toContain('Conversation-24');
+      expect(view.text()).not.toContain('Conversation-25');
+      view.input.write('n');
+      await vi.waitFor(() => expect(view.text()).toContain('26 / 60 · Showing 26–50'));
+      view.clear();
+      view.output.rows = 16;
+      view.output.emit('resize');
+      await vi.waitFor(() => expect(view.text()).toContain('Showing 26–35'));
+      view.input.write('n');
+      await vi.waitFor(() => expect(view.text()).toContain('36 / 60 · Showing 36–45'));
+      view.input.write('\r');
+      await view.app.waitUntilExit();
+      expect(view.select.mock.calls[0][0].sessionFile).toBe('/sessions/35.jsonl');
+    } finally { view.app.unmount(); view.app.cleanup(); view.input.destroy(); view.output.destroy(); }
+  });
+
+  it.each(['q', '\x1b', '\x03'])('cancels with %j and restores terminal input', async key => {
+    const view = mount();
+    try {
+      await vi.waitFor(() => expect(view.input.setRawMode).toHaveBeenCalledWith(true));
+      view.input.write(key);
+      await view.app.waitUntilExit();
+      expect(view.select).toHaveBeenCalledExactlyOnceWith(null);
+      expect(view.input.setRawMode).toHaveBeenLastCalledWith(false);
+    } finally { view.app.unmount(); view.app.cleanup(); view.input.destroy(); view.output.destroy(); }
+  });
+});

--- a/packages/happy-cli/src/codex/sessionPicker.tsx
+++ b/packages/happy-cli/src/codex/sessionPicker.tsx
@@ -1,0 +1,115 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { Box, Text, render, useApp, useInput, useStdout } from 'ink';
+import type { ResumeSession } from './cli';
+
+// Keep the picker compact even on very tall terminals. Leave room for chrome
+// and a spare terminal line to avoid scrolling the surrounding shell output.
+export function pickerPageSize(terminalRows: number): number {
+  return Math.max(1, Math.min(25, terminalRows - 6));
+}
+
+export function pickerWindow(count: number, selected: number, start: number, size: number) {
+  const index = Math.max(0, Math.min(selected, count - 1));
+  const length = Math.max(1, size);
+  const first = Math.max(0, Math.min(start, index, Math.max(0, count - length)));
+  const top = index >= first + length ? index - length + 1 : first;
+  return { selected: index, start: top, end: Math.min(count, top + length) };
+}
+
+export function sanitizeSessionPickerText(value: string): string {
+  // Session text must never inject terminal escape sequences or extra rows.
+  return value.replace(/[\x00-\x1f\x7f-\x9f\u2028\u2029]/g, ' ').trim();
+}
+
+export function formatSessionAge(updatedAt: number | undefined, now: number): string {
+  if (updatedAt === undefined || !Number.isFinite(updatedAt)) return 'unknown';
+  const minutes = Math.floor(Math.max(0, now - updatedAt) / 60_000);
+  if (minutes < 1) return 'now';
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  return `${Math.floor(hours / 24)}d ago`;
+}
+
+export function CodexSessionPicker({ sessions, onSelect }: {
+  sessions: readonly ResumeSession[];
+  onSelect: (session: ResumeSession | null) => void;
+}) {
+  const { stdout } = useStdout();
+  const { exit } = useApp();
+  const [dimensions, setDimensions] = useState(() => ({ rows: stdout.rows || 24, columns: stdout.columns || 80 }));
+  const [position, setPosition] = useState({ selected: 0, start: 0 });
+  const [now] = useState(Date.now);
+  const finished = useRef(false);
+  const size = pickerPageSize(dimensions.rows);
+  const window = pickerWindow(sessions.length, position.selected, position.start, size);
+
+  useEffect(() => {
+    const resize = () => setDimensions({ rows: stdout.rows || 24, columns: stdout.columns || 80 });
+    stdout.on('resize', resize);
+    return () => { stdout.off('resize', resize); };
+  }, [stdout]);
+
+  useInput((input, key) => {
+    if (finished.current) return;
+    if (key.return || key.escape || input.toLowerCase() === 'q' || (key.ctrl && input === 'c')) {
+      finished.current = true;
+      onSelect(key.return ? sessions[window.selected] ?? null : null);
+      exit();
+      return;
+    }
+    const pageUp = key.pageUp || input === 'p';
+    const pageDown = key.pageDown || input === 'n';
+    const paging = pageUp || pageDown;
+    const delta = pageUp ? -size : pageDown ? size : key.upArrow ? -1 : key.downArrow ? 1 : 0;
+    if (delta || key.home || key.end) {
+      setPosition(previous => {
+        const visible = pickerWindow(sessions.length, previous.selected, previous.start, size);
+        const target = key.home ? 0 : key.end ? sessions.length - 1 : visible.selected + delta;
+        // Page keys move the viewport as well as the selection. Arrow keys only
+        // scroll when the selected row leaves the current viewport.
+        const start = paging ? visible.start + delta : visible.start;
+        return pickerWindow(sessions.length, target, start, size);
+      });
+    }
+  });
+
+  const selected = sessions[window.selected];
+  const directory = sanitizeSessionPickerText(selected?.originalPath || 'unknown directory');
+  return (
+    <Box flexDirection="column" width={Math.max(1, dimensions.columns)}>
+      <Text bold wrap="truncate-end">Resume a Codex session</Text>
+      <Text dimColor wrap="truncate-end">
+        {sessions.length ? `${window.selected + 1} / ${sessions.length} · Showing ${window.start + 1}–${window.end}` : 'No sessions'}
+      </Text>
+      {sessions.slice(window.start, window.end).map((session, offset) => {
+        const active = window.start + offset === window.selected;
+        const title = sanitizeSessionPickerText(session.title || '') || 'Untitled session';
+        const id = sanitizeSessionPickerText(session.sessionId).slice(0, 6);
+        return (
+          <Text key={session.sessionFile} color={active ? 'cyan' : undefined} inverse={active} wrap="truncate-end">
+            {active ? '› ' : '  '}{formatSessionAge(session.updatedAt, now).padEnd(8)} {id}  {title}
+          </Text>
+        );
+      })}
+      <Text dimColor wrap="truncate-middle">Directory: {directory}</Text>
+      <Text dimColor wrap="truncate-end">↑/↓ select · n/p page · Enter resume · q cancel</Text>
+    </Box>
+  );
+}
+
+export async function selectCodexSession(sessions: readonly ResumeSession[]): Promise<ResumeSession | null> {
+  if (!sessions.length) return null;
+  let selected: ResumeSession | null = null;
+  const app = render(<CodexSessionPicker sessions={sessions} onSelect={value => { selected = value; }} />, {
+    exitOnCtrlC: false,
+    patchConsole: false,
+  });
+  try {
+    await app.waitUntilExit();
+    return selected;
+  } finally {
+    app.unmount();
+    app.cleanup();
+  }
+}

--- a/packages/happy-cli/src/codex/utils/codexSessionReader.test.ts
+++ b/packages/happy-cli/src/codex/utils/codexSessionReader.test.ts
@@ -84,6 +84,7 @@ describe('listCodexSessions', () => {
     const sessions = await listCodexSessions();
     expect(sessions).toHaveLength(1);
     expect(sessions[0].sessionId).toBe('555555');
+    expect(sessions[0].sessionFile).toBe(filePath);
     expect(sessions[0].originalPath).toBe('/workspace/happy');
     expect(sessions[0].title).toBe('Please optimize Codex session listing speed');
     expect(sessions[0].messageCount).toBe(1);
@@ -97,6 +98,69 @@ describe('listCodexSessions', () => {
     expect(cache.lastRun.filesReparsed).toBe(1);
     expect(cache.lastRun.resultCount).toBe(1);
   });
+
+  it.each([false, true])(
+    'keeps cross-directory sessions scoped to metadata (selectMostRecent=%s)',
+    async (selectMostRecent) => {
+      const sessionUuid = '11111111-2222-3333-4444-555555555555';
+      const sessionsDir = join(codexHomeDir, 'sessions');
+      mkdirSync(sessionsDir, { recursive: true });
+      const filePath = join(sessionsDir, `rollout-2026-03-11T000000-${sessionUuid}.jsonl`);
+      const originalCwd = join(tempRoot, 'original');
+      const latestCwd = join(tempRoot, 'latest');
+      const records = [
+        { type: 'session_meta', payload: { id: sessionUuid, cwd: originalCwd } },
+        { type: 'response_item', payload: {
+          role: 'user', content: [{ type: 'input_text', text: 'Continue in another directory' }],
+        } },
+        { type: 'turn_context', payload: { cwd: join(tempRoot, 'intermediate') } },
+        { type: 'turn_context', payload: { cwd: latestCwd } },
+      ];
+      writeFileSync(filePath, records.map(record => JSON.stringify(record)).join('\n') + '\n');
+
+      vi.resetModules();
+      const { listCodexSessions } = await import('./codexSessionReader');
+      const { resolveCodexResumeFile } = await import('../cli');
+      const { readCodexResumeDirectory } = await import('../resumeDirectory');
+      const invocation = { kind: 'resume' as const, includeAllDirectories: false, selectMostRecent };
+
+      // Exercise both a fresh index and its cached representation.
+      for (let pass = 0; pass < 2; pass++) {
+        const sessions = await listCodexSessions();
+        expect(sessions).toHaveLength(1);
+        expect(sessions[0].originalPath).toBe(originalCwd);
+        const cache = JSON.parse(readFileSync(join(happyHomeDir, 'codex-session-metadata-cache.json'), 'utf8'));
+        expect(cache.entries[filePath].originalPath).toBe(originalCwd);
+
+        const selectSession = vi.fn(async () => sessions[0]);
+        const dependencies = {
+          findSessionFile: () => filePath,
+          listSessions: async () => sessions,
+          isInteractive: () => true,
+          selectSession,
+        };
+        await expect(resolveCodexResumeFile(invocation, originalCwd, dependencies)).resolves.toBe(filePath);
+        if (selectMostRecent) {
+          expect(selectSession).not.toHaveBeenCalled();
+        } else {
+          expect(selectSession).toHaveBeenCalledWith(sessions);
+        }
+        selectSession.mockClear();
+        await expect(resolveCodexResumeFile(invocation, latestCwd, dependencies))
+          .rejects.toThrow('No resumable Codex session found');
+        expect(selectSession).not.toHaveBeenCalled();
+        await expect(resolveCodexResumeFile(
+          { ...invocation, includeAllDirectories: true }, latestCwd, dependencies,
+        )).resolves.toBe(filePath);
+        await expect(resolveCodexResumeFile(
+          { ...invocation, sessionId: sessions[0].sessionId }, latestCwd, dependencies,
+        )).resolves.toBe(filePath);
+      }
+
+      // List membership does not determine the working directory used after selection.
+      expect(await readCodexResumeDirectory(filePath)).toBe(latestCwd);
+    },
+  );
 
   it('keeps user messages on both sides of a compacted record', async () => {
     const sessionUuid = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';

--- a/packages/happy-cli/src/codex/utils/codexSessionReader.ts
+++ b/packages/happy-cli/src/codex/utils/codexSessionReader.ts
@@ -214,6 +214,7 @@ export async function readAllCodexSessionUserMessages(
 
 export interface CodexSessionIndexEntry {
   sessionId: string;
+  sessionFile: string;
   originalPath: string | null;
   title?: string | null;
   updatedAt?: number;
@@ -399,6 +400,7 @@ export async function listCodexSessions(): Promise<CodexSessionIndexEntry[]> {
 
     results.push({
       sessionId: metadata.sessionId,
+      sessionFile: filePath,
       originalPath: metadata.originalPath,
       title: metadata.title,
       updatedAt: metadata.updatedAt ?? stats.mtimeMs,

--- a/packages/happy-cli/src/index.ts
+++ b/packages/happy-cli/src/index.ts
@@ -30,6 +30,9 @@ import { handleUpdateCommand } from './commands/update'
 import { claudeCliPath } from './claude/claudeLocal'
 import { execFileSync } from 'node:child_process'
 import { PUBLIC_DAEMON_SUBCOMMANDS, resolveCliInvocation, suggestClosestCommand } from './cli/commandRouting'
+import { CODEX_CLI_HELP, CodexCliSelectionCancelledError, CodexCliUsageError, parseCodexCliInvocation, resolveCodexResumeFile } from './codex/cli'
+
+import { resolveCodexResumeDirectory } from './codex/resumeDirectory'
 
 // Give the process a distinctive title so it does not show up as a generic
 // `node ... dist/index.mjs ...` in `ps`/`pkill`. Otherwise tooling and AI agents that
@@ -121,15 +124,23 @@ process.title = ['happy-next-cli', ...process.argv.slice(2)].join(' ');
     // Handle codex command
     try {
       const { runCodex } = await import('@/codex/runCodex');
-      
-      // Parse startedBy argument
-      let startedBy: 'daemon' | 'terminal' | undefined = undefined;
-      for (let i = 1; i < args.length; i++) {
-        if (args[i] === '--started-by') {
-          startedBy = args[++i] as 'daemon' | 'terminal';
-        }
+
+      const codexInvocation = parseCodexCliInvocation(args.slice(1));
+      if (codexInvocation.kind === 'help') {
+        console.log(CODEX_CLI_HELP);
+        return;
       }
+
+      const resumeFile = codexInvocation.kind === 'resume'
+        ? await resolveCodexResumeFile(codexInvocation)
+        : undefined;
       
+      if (resumeFile && codexInvocation.kind === 'resume') {
+        const directory = await resolveCodexResumeDirectory(resumeFile, process.cwd(), codexInvocation.resumeCwd);
+        // Select cwd before creating Happy metadata or starting the Codex backend.
+        process.chdir(directory);
+      }
+
       const {
         credentials
       } = await authAndSetupMachineIfNeeded();
@@ -143,10 +154,16 @@ process.title = ['happy-next-cli', ...process.argv.slice(2)].join(' ');
         await new Promise(resolve => setTimeout(resolve, 200));
       }
 
-      await runCodex({credentials, startedBy});
+      await runCodex({ credentials, startedBy: codexInvocation.startedBy, resumeFile });
       // Do not force exit here; allow instrumentation to show lingering handles
     } catch (error) {
+      if (error instanceof CodexCliSelectionCancelledError) {
+        return;
+      }
       console.error(chalk.red('Error:'), error instanceof Error ? error.message : 'Unknown error')
+      if (error instanceof CodexCliUsageError) {
+        console.error(`Run ${chalk.cyan('happy codex --help')} for usage.`)
+      }
       if (isDebug()) {
         console.error(error)
       }
@@ -608,6 +625,7 @@ ${chalk.bold('Usage:')}
   happy -- <args>         Pass positional arguments directly to Claude
   happy auth              Manage authentication
   happy codex             Start Codex mode
+  happy codex resume      Select a Codex session to resume in this directory
   happy gemini            Start Gemini mode (ACP)
   happy connect           Connect AI vendor API keys
   happy notify            Send push notification

--- a/packages/happy-cli/src/persistence.ts
+++ b/packages/happy-cli/src/persistence.ts
@@ -204,6 +204,7 @@ interface Settings {
   machineId?: string
   machineIdConfirmedByServer?: boolean
   daemonAutoStartWhenRunningHappy?: boolean
+  codexResumeCwd?: 'session' | 'current' // CLI-only resume directory preference
   chromeMode?: boolean  // Default Chrome mode setting for Claude
   // Profile management settings (synced with happy app)
   activeProfileId?: string

--- a/packages/happy-cli/src/utils/MessageQueue2.test.ts
+++ b/packages/happy-cli/src/utils/MessageQueue2.test.ts
@@ -106,6 +106,22 @@ describe('MessageQueue2', () => {
         expect(result).toBeNull();
     });
 
+    it('should wake an active waiter when reset and remain reusable', async () => {
+        const queue = new MessageQueue2<string>(mode => mode);
+        const waitPromise = queue.waitForMessagesAndGetAsString();
+
+        queue.reset();
+
+        await expect(waitPromise).resolves.toBeNull();
+        expect(queue.isClosed()).toBe(false);
+
+        queue.push('after reset', 'local');
+        await expect(queue.waitForMessagesAndGetAsString()).resolves.toMatchObject({
+            message: 'after reset',
+            mode: 'local',
+        });
+    });
+
     it('should handle abort signal', async () => {
         const queue = new MessageQueue2<string>(mode => mode);
         const abortController = new AbortController();

--- a/packages/happy-cli/src/utils/MessageQueue2.ts
+++ b/packages/happy-cli/src/utils/MessageQueue2.ts
@@ -187,8 +187,14 @@ export class MessageQueue2<T, M = string> {
         this.queue = [];
         this.closed = false;
 
-        // Clear waiter without calling it since we're not closing
-        this.waiter = null;
+        // Wake an active consumer so it can observe the reset and decide
+        // whether to wait again. Dropping the waiter leaves its Promise
+        // pending forever, which prevents idle agent loops from exiting.
+        if (this.waiter) {
+            const waiter = this.waiter;
+            this.waiter = null;
+            waiter(false);
+        }
     }
 
     /**


### PR DESCRIPTION
## Summary

- Parse `happy codex` invocations instead of silently ignoring trailing arguments; support the default picker, `--last`, `--all`, and explicit session IDs.
- Resume the original Codex thread with `thread/resume`, backfill history, and explain active-writer conflicts without silently forking or taking over another writer.
- Use the existing Ink dependency for a compact scrolling picker, displaying at most **25 sessions** at a time, automatically reduced to fit terminal height (not a total session limit). Support arrows, `n/p`, Enter, and cancellation; retain PgUp/PgDn support when the terminal forwards those keys.
- Prefer `n/p` in the footer because code-server can consume PgUp/PgDn for terminal scrollback. No editor setting changes or alternate-screen mode are required.
- When the selected session's latest recorded cwd differs, offer session/current directory choices with optional Happy-only remembered preferences. Support `--resume-cwd session|current|ask`; resolve cwd before creating Happy session metadata and starting the backend.
- Preserve the existing Codex shutdown fix, restoring terminal input and waking idle queue consumers during termination.
- Correct the top-level resume help description.

## Scope and limitations

- The picker limits rendered rows, but still uses the existing session listing/loading implementation. No lazy-loading, search, archive controls, or full Codex TUI clone.
- App/Web resume behavior is unchanged.
- Codex startup/resume still occurs on the first app message; active-writer failures are not an eager startup check.
- A saved directory preference is local to Happy, not a change to native Codex configuration. `--resume-cwd ask` overrides it for a new selection.

## Review and validation

- Reviewed keyboard/page viewport behavior, resize handling, exact session-file selection, cancellation/raw-mode restoration, cwd precedence and persistence, and non-interactive behavior.
- `yarn typecheck` in `packages/happy-cli`: passed.
- Full-suite validation before the display-cap adjustment: **63 files, 573 tests passed**.
- Latest display-cap validation: **47 tests passed** across picker, CLI parsing, and resume-directory tests; typecheck and build passed. Added coverage for a 25-row viewport shrinking to 10 rows and paging by the actual visible count.
- `yarn build`: passed; checked the built top-level help output.
- Keyboard tests cover both PgUp/PgDn sequences and `n/p`, scrolling visible ranges, resize, duplicate short IDs, and cancel/terminal restoration.
- Isolated built-CLI PTY smoke testing during implementation covered selection followed by the cwd prompt and clean cancellation before auth/session creation.

Closes #33

