### PR TITLE
fix(cli): prevent Codex exit from hanging

### DIFF
--- a/packages/happy-cli/src/codex/appserver/CodexJsonRpcPeer.test.ts
+++ b/packages/happy-cli/src/codex/appserver/CodexJsonRpcPeer.test.ts
@@ -1,0 +1,71 @@
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { CodexJsonRpcPeer } from './CodexJsonRpcPeer';
+
+function processExists(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code !== 'ESRCH';
+  }
+}
+
+async function waitFor<T>(read: () => Promise<T | null>, timeoutMs = 2_000): Promise<T> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const value = await read();
+    if (value !== null) return value;
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+  throw new Error(`Condition was not met within ${timeoutMs}ms`);
+}
+
+describe.skipIf(process.platform === 'win32')('CodexJsonRpcPeer process cleanup', () => {
+  let processGroupId: number | null = null;
+  let tempDir: string | null = null;
+
+  afterEach(async () => {
+    if (processGroupId && processExists(processGroupId)) {
+      try { process.kill(-processGroupId, 'SIGKILL'); } catch { /* already exited */ }
+    }
+    if (tempDir) await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('kills the detached process group without leaving its child behind', async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'happy-codex-peer-'));
+    const childPidFile = join(tempDir, 'child.pid');
+    const peer = new CodexJsonRpcPeer();
+
+    await peer.spawn('/bin/sh', [
+      '-c',
+      'sleep 60 & echo $! > "$1"; wait',
+      'codex-test',
+      childPidFile,
+    ], { cwd: tempDir });
+
+    processGroupId = (peer as unknown as { process: { pid?: number } }).process.pid ?? null;
+    expect(processGroupId).not.toBeNull();
+
+    const childPid = await waitFor(async () => {
+      try {
+        const value = Number.parseInt(await readFile(childPidFile, 'utf8'), 10);
+        return Number.isFinite(value) ? value : null;
+      } catch {
+        return null;
+      }
+    });
+    expect(processExists(processGroupId!)).toBe(true);
+    expect(processExists(childPid)).toBe(true);
+
+    await peer.close();
+
+    await waitFor(async () => (
+      !processExists(processGroupId!) && !processExists(childPid) ? true : null
+    ));
+    expect(processExists(processGroupId!)).toBe(false);
+    expect(processExists(childPid)).toBe(false);
+  });
+});

--- a/packages/happy-cli/src/codex/runCodex.ts
+++ b/packages/happy-cli/src/codex/runCodex.ts
@@ -44,6 +44,7 @@ import type { AgentMessage } from '@/agent/core';
 import { handleConfigMetadataEvent } from '@/agent/acp/sessionUpdateHandlers';
 import { findCodexSessionFile } from './utils/codexSessionReader';
 import { summarizeBashToolOutput } from '@/modules/common/loadableToolOutput';
+import { cleanupStdinAfterInk } from '@/utils/terminalStdinCleanup';
 
 type ReadyEventOptions = {
     pending: unknown;
@@ -510,7 +511,58 @@ export async function runCodex(opts: {
         clearInterval(keepAliveInterval);
         messageQueue.reset();
 
+        // Restore the terminal before any asynchronous cleanup. If a backend
+        // or network close stalls, leaving Ink mounted keeps the shell in raw
+        // mode and the user sees an indefinitely frozen exit screen.
+        if (inkInstance) {
+            inkInstance.unmount();
+            inkInstance = null;
+        }
+        await cleanupStdinAfterInk({
+            stdin: process.stdin,
+            drainMs: 0,
+            leaveRawMode: false,
+        });
+
+        const forcedExitTimer = setTimeout(() => {
+            logger.debug('[Codex] Timed out during session termination, forcing exit');
+            process.exit(0);
+        }, 12_000);
+
+        const runCleanupStep = async (
+            label: string,
+            cleanup: () => Promise<unknown>,
+            timeoutMs: number,
+        ): Promise<void> => {
+            let timeout: ReturnType<typeof setTimeout> | undefined;
+            try {
+                await Promise.race([
+                    cleanup(),
+                    new Promise<never>((_, reject) => {
+                        timeout = setTimeout(
+                            () => reject(new Error(`${label} timed out after ${timeoutMs}ms`)),
+                            timeoutMs,
+                        );
+                    }),
+                ]);
+            } catch (error) {
+                logger.debug(`[Codex] ${label} failed during termination`, error);
+            } finally {
+                if (timeout) clearTimeout(timeout);
+            }
+        };
+
         try {
+            // Kill the Codex process group before doing any network cleanup.
+            // This ensures a stalled flush cannot leave app-server orphaned
+            // when the forced-exit watchdog fires.
+            await handleAbort();
+            await runCleanupStep('backend.dispose', async () => backend?.dispose(), 6_000);
+            backend = null;
+
+            stopCaffeinate();
+            mcp.stop();
+
             if (session) {
                 session.updateMetadata((currentMetadata) => ({
                     ...currentMetadata,
@@ -520,34 +572,20 @@ export async function runCodex(opts: {
                     archiveReason: 'User terminated'
                 }));
                 session.sendSessionDeath();
-                await session.flush();
-                await session.close();
+                await runCleanupStep('session.flush', () => session.flush(), 2_000);
+                await runCleanupStep('session.close', () => session.close(), 2_000);
             }
         } catch (error) {
             logger.debug('[Codex] Error while ending session during termination', error);
         }
 
         try {
-            await handleAbort();
-            logger.debug('[Codex] Abort completed, proceeding with backend disposal');
-        } catch (error) {
-            logger.debug('[Codex] Error during abort in termination flow', error);
-        }
-
-        try {
-            try {
-                await backend?.dispose();
-            } catch (e) {
-                logger.debug('[Codex] Error while disposing backend during termination', e);
-            }
-
-            stopCaffeinate();
-            mcp.stop();
-
             logger.debug('[Codex] Session termination complete, exiting');
+            clearTimeout(forcedExitTimer);
             process.exit(0);
         } catch (error) {
             logger.debug('[Codex] Error during session termination:', error);
+            clearTimeout(forcedExitTimer);
             process.exit(1);
         }
     };
@@ -571,8 +609,7 @@ export async function runCodex(opts: {
             logPath: isDebug() ? logger.getLogPath() : undefined,
             onExit: async () => {
                 logger.debug('[codex]: Exiting agent via Ctrl-C');
-                shouldExit = true;
-                await handleAbort();
+                await handleKillSession();
             }
         }), {
             exitOnCtrlC: false,
@@ -1379,6 +1416,11 @@ Tokens used: ${goal.tokensUsed}${goal.tokenBudget ? ` / ${goal.tokenBudget}` : '
     } finally {
         logger.debug('[codex]: Final cleanup start');
         logActiveHandles('cleanup-start');
+
+        if (isTerminating) {
+            logger.debug('[codex]: Final cleanup is owned by the termination handler');
+            return;
+        }
 
         if (reconnectionHandle) {
             logger.debug('[codex]: Cancelling offline reconnection');

--- a/packages/happy-cli/src/utils/MessageQueue2.test.ts
+++ b/packages/happy-cli/src/utils/MessageQueue2.test.ts
@@ -106,6 +106,22 @@ describe('MessageQueue2', () => {
         expect(result).toBeNull();
     });
 
+    it('should wake an active waiter when reset and remain reusable', async () => {
+        const queue = new MessageQueue2<string>(mode => mode);
+        const waitPromise = queue.waitForMessagesAndGetAsString();
+
+        queue.reset();
+
+        await expect(waitPromise).resolves.toBeNull();
+        expect(queue.isClosed()).toBe(false);
+
+        queue.push('after reset', 'local');
+        await expect(queue.waitForMessagesAndGetAsString()).resolves.toMatchObject({
+            message: 'after reset',
+            mode: 'local',
+        });
+    });
+
     it('should handle abort signal', async () => {
         const queue = new MessageQueue2<string>(mode => mode);
         const abortController = new AbortController();

--- a/packages/happy-cli/src/utils/MessageQueue2.ts
+++ b/packages/happy-cli/src/utils/MessageQueue2.ts
@@ -187,8 +187,14 @@ export class MessageQueue2<T, M = string> {
         this.queue = [];
         this.closed = false;
 
-        // Clear waiter without calling it since we're not closing
-        this.waiter = null;
+        // Wake an active consumer so it can observe the reset and decide
+        // whether to wait again. Dropping the waiter leaves its Promise
+        // pending forever, which prevents idle agent loops from exiting.
+        if (this.waiter) {
+            const waiter = this.waiter;
+            this.waiter = null;
+            waiter(false);
+        }
     }
 
     /**


### PR DESCRIPTION
## Summary

- route terminal Ctrl-C through the complete Codex termination flow
- wake idle message consumers and restore terminal state before asynchronous cleanup
- terminate the Codex process group before bounded server flush/close operations
- prevent concurrent duplicate cleanup and retain a forced-exit watchdog
- add regression coverage for queue reset and real detached process-group cleanup

## Validation

- `yarn typecheck` in `packages/happy-cli`
- `npx vitest run src/codex/appserver/CodexJsonRpcPeer.test.ts src/codex/appserver/CodexAppServerBackend.test.ts src/utils/MessageQueue2.test.ts src/utils/terminalStdinCleanup.test.ts` (70 tests)