### PR TITLE
fix(codex): fork sessions through native app-server

### DIFF
--- a/packages/happy-cli/src/codex/appserver/types.ts
+++ b/packages/happy-cli/src/codex/appserver/types.ts
@@ -138,6 +138,19 @@ export interface ThreadResumeResponse {
   serviceTier?: ServiceTier | null;
 }
 
+export interface ThreadForkParams {
+  threadId: string;
+  excludeTurns: boolean;
+  lastTurnId?: string;
+}
+
+export type ThreadForkResponse = ThreadStartResponse;
+
+export interface ThreadTurnsListResponse {
+  data: Turn[];
+  nextCursor: string | null;
+}
+
 // ─── Turn Management ───────────────────────────────────────────
 
 export interface TurnStartParams {
@@ -390,6 +403,8 @@ export const Methods = {
   INITIALIZED: 'initialized',
   THREAD_START: 'thread/start',
   THREAD_RESUME: 'thread/resume',
+  THREAD_FORK: 'thread/fork',
+  THREAD_TURNS_LIST: 'thread/turns/list',
   TURN_START: 'turn/start',
   TURN_INTERRUPT: 'turn/interrupt',
   REVIEW_START: 'review/start',

--- a/packages/happy-cli/src/codex/utils/codexBackfill.ts
+++ b/packages/happy-cli/src/codex/utils/codexBackfill.ts
@@ -6,7 +6,6 @@
  * conversation history when a session is resumed or copied.
  */
 
-import { readFile } from 'node:fs/promises';
 import { basename, isAbsolute } from 'node:path';
 import { logger } from '@/ui/logger';
 import {
@@ -14,6 +13,7 @@ import {
     extractUserText,
     isSystemMessage,
     generateStableUuid,
+    readCodexSessionContent,
 } from './codexSessionReader';
 
 export interface CodexBackfillOptions {
@@ -108,7 +108,7 @@ export async function backfillCodexSessionHistory(opts: CodexBackfillOptions): P
 
     let content: string;
     try {
-        content = await readFile(filePath, 'utf-8');
+        content = await readCodexSessionContent(filePath);
     } catch (error) {
         logger.debug(`[CODEX-BACKFILL] Failed to read file: ${filePath}`, error);
         return;

--- a/packages/happy-cli/src/codex/utils/codexSessionFork.integration.test.ts
+++ b/packages/happy-cli/src/codex/utils/codexSessionFork.integration.test.ts
@@ -1,0 +1,142 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { randomUUID } from 'node:crypto';
+import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { forkAndTruncateCodexSession, forkCodexSession } from './codexSessionFork';
+import { generateStableUuid, getCodexSessionPreview, listCodexSessions, readAllCodexSessionUserMessages } from './codexSessionReader';
+import { backfillCodexSessionHistory } from './codexBackfill';
+import { CodexAppServerBackend } from '../appserver/CodexAppServerBackend';
+import { CODEX_PACKAGE } from '../package';
+
+vi.mock('@/configuration', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/configuration')>();
+  return {
+    ...actual,
+    configuration: {
+      ...actual.configuration,
+      get happyHomeDir() { return process.env.HAPPY_HOME_DIR ?? actual.configuration.happyHomeDir; },
+    },
+  };
+});
+
+// Real app-server, isolated history and an unreachable fixture provider. No model turns are started.
+describe('native Codex forks', () => {
+  let home: string;
+  let originalCodexHome: string | undefined;
+  let originalHappyHome: string | undefined;
+  let backend: CodexAppServerBackend | undefined;
+  const timestamp = '2026-09-01T00:00:00.000Z';
+
+  beforeEach(async () => {
+    home = await mkdtemp(join(tmpdir(), 'happy-native-codex-fork-'));
+    originalCodexHome = process.env.CODEX_HOME;
+    originalHappyHome = process.env.HAPPY_HOME_DIR;
+    process.env.CODEX_HOME = home;
+    process.env.HAPPY_HOME_DIR = join(home, 'happy');
+    await mkdir(join(home, 'sessions'));
+    await writeFile(join(home, 'config.toml'), [
+      'model = "fixture-model"',
+      'model_provider = "fixture"',
+      '[model_providers.fixture]',
+      'name = "fixture"',
+      'base_url = "http://127.0.0.1:9"',
+      'wire_api = "responses"',
+    ].join('\n'));
+  });
+
+  afterEach(async () => {
+    await backend?.dispose();
+    backend = undefined;
+    if (originalCodexHome === undefined) delete process.env.CODEX_HOME;
+    else process.env.CODEX_HOME = originalCodexHome;
+    if (originalHappyHome === undefined) delete process.env.HAPPY_HOME_DIR;
+    else process.env.HAPPY_HOME_DIR = originalHappyHome;
+    await rm(home, { recursive: true, force: true });
+  });
+
+  async function createSource(historyMode: 'paginated' | 'legacy') {
+    const id = randomUUID();
+    const path = join(home, 'sessions', `rollout-2026-09-01T00-00-00-${id}.jsonl`);
+    const rows: unknown[] = [{
+      type: 'session_meta', timestamp,
+      payload: {
+        id, session_id: id, timestamp, cwd: home, originator: 'codex_cli_rs', cli_version: '0.153.2',
+        source: 'cli', model_provider: 'fixture', history_mode: historyMode, base_instructions: { text: 'Fixture instructions' },
+      },
+    }];
+    for (let i = 0; i < 3; i++) {
+      const turnId = randomUUID();
+      rows.push(
+        { type: 'event_msg', timestamp, payload: { type: 'task_started', turn_id: turnId, model_context_window: 100000 } },
+        { type: 'response_item', timestamp, payload: { type: 'message', id: randomUUID(), role: 'user', content: [{ type: 'input_text', text: `Question ${i}` }] } },
+        { type: 'event_msg', timestamp, payload: { type: 'user_message', message: `Question ${i}`, images: [], local_images: [], text_elements: [] } },
+        { type: 'response_item', timestamp, payload: { type: 'message', id: randomUUID(), role: 'assistant', content: [{ type: 'output_text', text: `Answer ${i}` }] } },
+        { type: 'event_msg', timestamp, payload: { type: 'task_complete', turn_id: turnId, last_agent_message: `Answer ${i}` } },
+      );
+    }
+    const content = rows.map((row, ordinal) => JSON.stringify({ ...row as object, ordinal })).join('\n') + '\n';
+    await writeFile(path, content);
+    // Materialize the fixture's native indexes just as a real source session would have done.
+    const sourceBackend = new CodexAppServerBackend({
+      command: 'npx', args: ['-y', CODEX_PACKAGE, 'app-server'], cwd: home, resumeFile: path,
+    });
+    try {
+      await sourceBackend.startSession();
+    } finally {
+      await sourceBackend.dispose();
+    }
+    return { id, path, content: await readFile(path, 'utf-8') };
+  }
+
+  it.each([
+    ['paginated', false], ['paginated', true], ['legacy', false], ['legacy', true],
+  ] as const)('resumes a %s fork after process shutdown and a model change (truncate=%s)', async (mode, truncate) => {
+    const source = await createSource(mode);
+    const fork = await forkAndTruncateCodexSession(source.id, truncate ? generateStableUuid(timestamp, 1) : undefined);
+    expect(fork, fork.errorMessage).toMatchObject({ success: true, newFilePath: expect.any(String) });
+    const metadata = JSON.parse((await readFile(fork.newFilePath!, 'utf-8')).split('\n')[0]).payload;
+    expect(metadata.id).not.toBe(source.id);
+    expect(fork.newFilePath).toContain(metadata.id);
+    expect(metadata.cwd).toBe(home);
+
+    const expectedQuestions = truncate ? ['Question 0'] : ['Question 0', 'Question 1', 'Question 2'];
+    expect((await readAllCodexSessionUserMessages(metadata.id)).map(message => message.content)).toEqual(expectedQuestions);
+    expect((await getCodexSessionPreview(metadata.id)).filter(message => message.role === 'user').map(message => message.content)).toEqual(expectedQuestions);
+
+    backend = new CodexAppServerBackend({
+      command: 'npx', args: ['-y', CODEX_PACKAGE, 'app-server'], cwd: home,
+      resumeFile: fork.newFilePath, model: 'changed-fixture-model',
+    });
+    expect(await backend.startSession()).toEqual({ sessionId: metadata.id });
+    expect(await readFile(source.path, 'utf-8')).toBe(source.content);
+  }, 60_000);
+
+  it('lists, backfills and forks inherited paginated messages without copying later parent updates', async () => {
+    const source = await createSource('paginated');
+    const fork = await forkCodexSession(source.id);
+    expect(fork, fork.errorMessage).toMatchObject({ success: true });
+    const metadata = JSON.parse((await readFile(fork.newFilePath!, 'utf-8')).split('\n')[0]).payload;
+    const lastOrdinal = JSON.parse(source.content.trimEnd().split('\n').at(-1)!).ordinal;
+    await writeFile(source.path, source.content + JSON.stringify({
+      type: 'response_item', timestamp, ordinal: lastOrdinal + 1,
+      payload: { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'Later parent message' }] },
+    }) + '\n');
+
+    const messages = await readAllCodexSessionUserMessages(metadata.id);
+    expect(messages.map(message => message.content)).toEqual(['Question 0', 'Question 1', 'Question 2']);
+    const sessions = await listCodexSessions();
+    expect(sessions.find(session => session.sessionId === metadata.id.slice(-6))).toMatchObject({ title: 'Question 0', messageCount: 3 });
+    const batches: unknown[] = [];
+    await backfillCodexSessionHistory({ sessionIdOrPath: fork.newFilePath!, sendBatch: async batch => { batches.push(...batch); } });
+    expect(batches.length).toBeGreaterThan(0);
+    expect(JSON.stringify(batches)).toContain('Question 0');
+    expect(JSON.stringify(batches)).not.toContain('Later parent message');
+
+    const secondFork = await forkAndTruncateCodexSession(metadata.id, messages[1].uuid);
+    expect(secondFork, secondFork.errorMessage).toMatchObject({ success: true });
+    const secondId = JSON.parse((await readFile(secondFork.newFilePath!, 'utf-8')).split('\n')[0]).payload.id;
+    expect(secondId).not.toBe(metadata.id);
+    expect((await readAllCodexSessionUserMessages(secondId)).map(message => message.content)).toEqual(['Question 0']);
+  }, 60_000);
+});

--- a/packages/happy-cli/src/codex/utils/codexSessionFork.test.ts
+++ b/packages/happy-cli/src/codex/utils/codexSessionFork.test.ts
@@ -1,0 +1,174 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdtemp, mkdir, readFile, readdir, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { forkAndTruncateCodexSession, forkCodexSession } from './codexSessionFork';
+import { generateStableUuid } from './codexSessionReader';
+import { Methods } from '../appserver/types';
+import { CODEX_PACKAGE } from '../package';
+
+const peer = vi.hoisted(() => ({ spawn: vi.fn(), request: vi.fn(), notify: vi.fn(), close: vi.fn() }));
+vi.mock('../appserver/CodexJsonRpcPeer', () => ({ CodexJsonRpcPeer: vi.fn(() => peer) }));
+
+const sourceId = '11111111-2222-4333-8444-555555555555';
+const forkId = 'aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee';
+const timestamp = '2026-09-04T06:59:26.000Z';
+const user = (text: string) => ({ type: 'response_item', timestamp, payload: { role: 'user', content: [{ type: 'input_text', text }] } });
+const started = (id: string) => ({ type: 'event_msg', timestamp, payload: { type: 'task_started', turn_id: id } });
+
+describe('Codex session fork', () => {
+  let home: string;
+  let sourcePath: string;
+  let forkPath: string;
+  let sourceContent: string;
+
+  async function writeSource(records: unknown[]) {
+    sourceContent = records.map((record) => JSON.stringify(record)).join('\n') + '\n';
+    await writeFile(sourcePath, sourceContent);
+  }
+
+  beforeEach(async () => {
+    vi.resetAllMocks();
+    home = await mkdtemp(join(tmpdir(), 'happy-codex-fork-'));
+    vi.stubEnv('CODEX_HOME', home);
+    const sessions = join(home, 'sessions');
+    await mkdir(sessions);
+    sourcePath = join(sessions, `rollout-2026-09-04T06-59-26-${sourceId}.jsonl`);
+    forkPath = join(sessions, `rollout-2026-09-05T01-38-15-${forkId}.jsonl`);
+    await writeSource([
+      { type: 'session_meta', timestamp, payload: { id: sourceId, session_id: sourceId, history_mode: 'paginated' } },
+      started('turn-1'), user('# AGENTS.md\nSystem context'), user('First question'),
+      { type: 'compacted', timestamp, payload: { message: 'summary' } },
+      started('turn-2'), user('Second question'),
+      started('turn-3'), user('Third question'),
+    ]);
+    peer.request.mockImplementation(async (method: string) => {
+      if (method === Methods.INITIALIZE) return {};
+      if (method === Methods.THREAD_TURNS_LIST) {
+        return { data: ['turn-1', 'turn-2', 'turn-3'].map((id) => ({ id })), nextCursor: null };
+      }
+      if (method === Methods.THREAD_FORK) {
+        await writeFile(forkPath, JSON.stringify({ type: 'session_meta', payload: { id: forkId } }) + '\n');
+        return { thread: { id: forkId, path: forkPath } };
+      }
+      throw new Error(`Unexpected request: ${method}`);
+    });
+  });
+
+  afterEach(async () => {
+    vi.unstubAllEnvs();
+    await rm(home, { recursive: true, force: true });
+  });
+
+  it('forks paginated history by canonical ID, never by copying or resuming the source', async () => {
+    expect(await forkCodexSession(sourceId)).toEqual({ success: true, newFilePath: forkPath });
+    expect(peer.spawn).toHaveBeenCalledWith('npx', ['-y', CODEX_PACKAGE, 'app-server'], { cwd: process.cwd() });
+    expect(peer.request).toHaveBeenNthCalledWith(1, Methods.INITIALIZE, expect.objectContaining({ capabilities: { experimentalApi: true } }));
+    expect(peer.notify).toHaveBeenCalledWith(Methods.INITIALIZED);
+    expect(peer.request).toHaveBeenNthCalledWith(2, Methods.THREAD_FORK, { threadId: sourceId, excludeTurns: true });
+    expect(peer.request).toHaveBeenCalledTimes(2);
+    expect(await readFile(sourcePath, 'utf-8')).toBe(sourceContent);
+    expect(await readdir(join(home, 'sessions'))).toHaveLength(2);
+    expect(peer.close).toHaveBeenCalledOnce();
+  });
+
+  it('resolves display suffixes to the full native thread ID', async () => {
+    expect((await forkCodexSession('555555')).success).toBe(true);
+    expect(peer.request).toHaveBeenCalledWith(Methods.THREAD_FORK, { threadId: sourceId, excludeTurns: true });
+  });
+
+  it('forks through the previous turn, excluding the selected message and later history', async () => {
+    expect((await forkAndTruncateCodexSession(sourceId, generateStableUuid(timestamp, 1))).success).toBe(true);
+    expect(peer.request).toHaveBeenCalledWith(Methods.THREAD_FORK, { threadId: sourceId, excludeTurns: true, lastTurnId: 'turn-1' });
+    expect(await readFile(sourcePath, 'utf-8')).toBe(sourceContent);
+  });
+
+  it('keeps the previous turn across native pagination pages', async () => {
+    peer.request.mockReset()
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({ data: [{ id: 'turn-1' }], nextCursor: 'page-2' })
+      .mockResolvedValueOnce({ data: [{ id: 'turn-2' }], nextCursor: null })
+      .mockImplementationOnce(async () => {
+        await writeFile(forkPath, 'native fork');
+        return { thread: { id: forkId, path: forkPath } };
+      });
+    expect((await forkAndTruncateCodexSession(sourceId, generateStableUuid(timestamp, 1))).success).toBe(true);
+    expect(peer.request).toHaveBeenCalledWith(Methods.THREAD_TURNS_LIST, {
+      threadId: sourceId, cursor: 'page-2', sortDirection: 'asc', limit: 100, itemsView: 'notLoaded',
+    });
+    expect(peer.request).toHaveBeenLastCalledWith(Methods.THREAD_FORK, { threadId: sourceId, excludeTurns: true, lastTurnId: 'turn-1' });
+  });
+
+  it('rejects old renamed copies instead of accidentally forking their original thread', async () => {
+    await writeFile(forkPath, sourceContent);
+    expect(await forkCodexSession(forkId)).toEqual({ success: false, errorMessage: expect.stringContaining('does not match its thread id') });
+    expect(peer.spawn).not.toHaveBeenCalled();
+  });
+
+  it('rejects a missing source before spawning Codex', async () => {
+    expect((await forkCodexSession('missing')).success).toBe(false);
+    expect(peer.spawn).not.toHaveBeenCalled();
+  });
+
+  it('rejects missing metadata', async () => {
+    await writeSource([user('Question')]);
+    expect(await forkCodexSession(sourceId)).toEqual({ success: false, errorMessage: expect.stringContaining('metadata') });
+    expect(peer.spawn).not.toHaveBeenCalled();
+  });
+
+  it('rejects an unknown truncation UUID instead of silently copying the entire session', async () => {
+    expect(await forkAndTruncateCodexSession(sourceId, 'missing')).toEqual({ success: false, errorMessage: expect.stringContaining('not found') });
+    expect(peer.spawn).not.toHaveBeenCalled();
+  });
+
+  it('rejects first-turn truncation rather than returning a full fork', async () => {
+    expect(await forkAndTruncateCodexSession(sourceId, generateStableUuid(timestamp, 0))).toEqual({ success: false, errorMessage: expect.stringContaining('first Codex turn') });
+    expect(peer.request).not.toHaveBeenCalledWith(Methods.THREAD_FORK, expect.anything());
+    expect(peer.close).toHaveBeenCalledOnce();
+  });
+
+  it('rejects a mid-turn message rather than dropping earlier messages in that turn', async () => {
+    await writeFile(sourcePath, sourceContent + JSON.stringify(user('Steered question')) + '\n');
+    expect(await forkAndTruncateCodexSession(sourceId, generateStableUuid(timestamp, 3))).toEqual({ success: false, errorMessage: expect.stringContaining('middle of a Codex turn') });
+    expect(peer.spawn).not.toHaveBeenCalled();
+  });
+
+  it('rejects a selected turn no longer present in native history', async () => {
+    peer.request.mockReset().mockResolvedValueOnce({}).mockResolvedValueOnce({ data: [{ id: 'turn-1' }], nextCursor: null });
+    expect(await forkAndTruncateCodexSession(sourceId, generateStableUuid(timestamp, 1))).toEqual({ success: false, errorMessage: expect.stringContaining('no longer present') });
+    expect(peer.close).toHaveBeenCalledOnce();
+  });
+
+  it('stops on repeated pagination cursors', async () => {
+    peer.request.mockReset().mockResolvedValueOnce({}).mockResolvedValue({ data: [{ id: 'turn-1' }], nextCursor: 'same' });
+    expect(await forkAndTruncateCodexSession(sourceId, generateStableUuid(timestamp, 1))).toEqual({ success: false, errorMessage: expect.stringContaining('repeated') });
+    expect(peer.request).toHaveBeenCalledTimes(3);
+  });
+
+  it.each(['spawn', 'initialize', 'fork'])('closes the peer after a %s failure without falling back to resume', async (phase) => {
+    if (phase === 'spawn') peer.spawn.mockRejectedValueOnce(new Error('failed'));
+    else if (phase === 'initialize') peer.request.mockRejectedValueOnce(new Error('failed'));
+    else peer.request.mockReset().mockResolvedValueOnce({}).mockRejectedValueOnce(new Error('failed'));
+    expect(await forkCodexSession(sourceId)).toEqual({ success: false, errorMessage: 'failed' });
+    expect(peer.close).toHaveBeenCalledOnce();
+    expect(peer.request).not.toHaveBeenCalledWith(Methods.THREAD_RESUME, expect.anything());
+    expect(await readFile(sourcePath, 'utf-8')).toBe(sourceContent);
+    expect(await readdir(join(home, 'sessions'))).toHaveLength(1);
+  });
+
+  it.each([
+    { id: sourceId, path: '/tmp/fork.jsonl' },
+    { id: forkId, path: null },
+    { id: forkId, path: 'relative.jsonl' },
+  ])('rejects an invalid native fork result: %j', async (thread) => {
+    peer.request.mockReset().mockResolvedValueOnce({}).mockResolvedValueOnce({ thread });
+    expect(await forkCodexSession(sourceId)).toEqual({ success: false, errorMessage: expect.stringContaining('independent persisted fork') });
+    expect(peer.close).toHaveBeenCalledOnce();
+  });
+
+  it('does not return a rollout path that has not been persisted', async () => {
+    peer.request.mockReset().mockResolvedValueOnce({}).mockResolvedValueOnce({ thread: { id: forkId, path: forkPath } });
+    expect((await forkCodexSession(sourceId)).success).toBe(false);
+    expect(peer.close).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/happy-cli/src/codex/utils/codexSessionFork.ts
+++ b/packages/happy-cli/src/codex/utils/codexSessionFork.ts
@@ -1,18 +1,13 @@
-/**
- * Codex Session Fork
- *
- * Fork and truncate Codex CLI's native JSONL session files for the duplicate feature.
- * Codex stores sessions at ~/.codex/sessions/{yyyy}/{mm}/{dd}/rollout-{datetime}-{conversationId}.jsonl
- *
- * Unlike Gemini (where Happy manages the JSONL files and uses Happy session IDs as filenames),
- * Codex fork returns a file path — the Codex CLI uses file paths for its native resumeConversation RPC.
- */
+/** Fork native Codex history through app-server so IDs and paginated indexes stay consistent. */
 
-import { randomUUID } from 'node:crypto';
-import { copyFile, readFile, writeFile, unlink as unlinkAsync } from 'node:fs/promises';
-import { dirname, join, basename } from 'node:path';
+import { stat } from 'node:fs/promises';
+import { basename, isAbsolute } from 'node:path';
+import { z } from 'zod';
 import { logger } from '@/ui/logger';
-import { findCodexSessionFile, generateStableUuid, extractUserText, isSystemMessage } from './codexSessionReader';
+import { CODEX_PACKAGE } from '@/codex/package';
+import { CodexJsonRpcPeer } from '../appserver/CodexJsonRpcPeer';
+import { Methods, type InitializeParams, type ThreadForkParams, type ThreadForkResponse, type ThreadTurnsListResponse } from '../appserver/types';
+import { findCodexSessionFile, generateStableUuid, extractUserText, isSystemMessage, readCodexSessionContent } from './codexSessionReader';
 
 export interface CodexForkResult {
   success: boolean;
@@ -21,85 +16,125 @@ export interface CodexForkResult {
   errorMessage?: string;
 }
 
-/**
- * Fork a Codex session without truncation.
- * Copies the JSONL file to a new file with a fresh UUID in the same directory.
- */
+const rolloutRecordSchema = z.object({
+  type: z.string(),
+  timestamp: z.string().optional(),
+  payload: z.record(z.unknown()),
+});
+
+function readForkSource(content: string, truncateBeforeUuid?: string) {
+  let threadId: string | undefined;
+  let currentTurnId: string | undefined;
+  let targetTurnId: string | undefined;
+  let userIndex = 0;
+  const turnsWithUserMessages = new Set<string>();
+
+  for (const line of content.split('\n')) {
+    let value: unknown;
+    try { value = JSON.parse(line); } catch { continue; }
+    const result = rolloutRecordSchema.safeParse(value);
+    if (!result.success) continue;
+    const { type, payload, timestamp } = result.data;
+
+    if (type === 'session_meta' && typeof payload.id === 'string') {
+      threadId = payload.id;
+      if (!truncateBeforeUuid) break;
+    }
+    if (type === 'event_msg' && payload.type === 'task_started') {
+      currentTurnId = typeof payload.turn_id === 'string' ? payload.turn_id : undefined;
+    } else if (type === 'turn_context' && typeof payload.turn_id === 'string') {
+      currentTurnId = payload.turn_id;
+    }
+
+    if (type !== 'response_item' || payload.role !== 'user') continue;
+    const text = extractUserText(payload);
+    if (!text || isSystemMessage(text)) continue;
+    if (generateStableUuid(timestamp ?? '', userIndex) === truncateBeforeUuid) {
+      if (!currentTurnId) throw new Error('Cannot resolve the selected message to a Codex turn');
+      if (turnsWithUserMessages.has(currentTurnId)) {
+        throw new Error('Cannot fork before a message in the middle of a Codex turn; select the first message of a later turn');
+      }
+      targetTurnId = currentTurnId;
+      break;
+    }
+    if (currentTurnId) turnsWithUserMessages.add(currentTurnId);
+    userIndex++;
+  }
+
+  if (!threadId) throw new Error('Codex session metadata is missing a thread id');
+  if (truncateBeforeUuid && !targetTurnId) throw new Error('Selected Codex message was not found in the session');
+  return { threadId, targetTurnId };
+}
+
+async function findPreviousTurn(peer: CodexJsonRpcPeer, threadId: string, targetTurnId: string): Promise<string> {
+  let previousTurnId: string | undefined;
+  let cursor: string | null = null;
+  const visitedCursors = new Set<string>();
+  do {
+    const page: ThreadTurnsListResponse = await peer.request(Methods.THREAD_TURNS_LIST, {
+      threadId, cursor, sortDirection: 'asc', limit: 100, itemsView: 'notLoaded',
+    });
+    for (const turn of page.data) {
+      if (turn.id === targetTurnId) {
+        if (!previousTurnId) {
+          throw new Error('Cannot fork before the first Codex turn; start a new session instead');
+        }
+        return previousTurnId;
+      }
+      previousTurnId = turn.id;
+    }
+    cursor = page.nextCursor;
+    if (cursor) {
+      if (visitedCursors.has(cursor)) throw new Error('Codex returned a repeated turn pagination cursor');
+      visitedCursors.add(cursor);
+    }
+  } while (cursor);
+  throw new Error('Selected Codex turn is no longer present in the session');
+}
+
 export async function forkCodexSession(codexSessionId: string): Promise<CodexForkResult> {
   return forkAndTruncateCodexSession(codexSessionId);
 }
 
-/**
- * Fork a Codex session and optionally truncate at a specific UUID.
- *
- * The UUID is a stable hash generated by codexSessionReader (codex:{timestamp}:{index}).
- * To truncate, we re-count user messages during copy to find the matching one.
- */
+/** Preserve history before the selected user message, never mutating the source thread. */
 export async function forkAndTruncateCodexSession(
   codexSessionId: string,
   truncateBeforeUuid?: string,
 ): Promise<CodexForkResult> {
-  const originalPath = findCodexSessionFile(codexSessionId);
-  if (!originalPath) {
-    return { success: false, errorMessage: `Codex session file not found for: ${codexSessionId}` };
-  }
-
-  // Generate new filename in the same directory
-  const dir = dirname(originalPath);
-  const now = new Date();
-  const dateStr = now.toISOString().replace(/[:.]/g, '-').slice(0, 19);
-  const newUUID = randomUUID();
-  const newPath = join(dir, `rollout-${dateStr}-${newUUID}.jsonl`);
-
+  let peer: CodexJsonRpcPeer | undefined;
   try {
-    if (!truncateBeforeUuid) {
-      // Simple copy — no truncation
-      await copyFile(originalPath, newPath);
-    } else {
-      // Copy with truncation: keep lines before the user message matching the UUID
-      const content = await readFile(originalPath, 'utf-8');
-      const lines = content.split('\n');
-      const outputLines: string[] = [];
-      let userIndex = 0;
-      let foundTruncationPoint = false;
-
-      for (const line of lines) {
-        if (!line.trim()) continue;
-        if (foundTruncationPoint) continue;
-
-        try {
-          const parsed = JSON.parse(line);
-
-          // Check if this is the user message we want to truncate at
-          if (parsed.type === 'response_item' && parsed.payload?.role === 'user') {
-            const text = extractUserText(parsed.payload);
-            if (text && !isSystemMessage(text)) {
-              const timestamp = parsed.timestamp || '';
-              const uuid = generateStableUuid(timestamp, userIndex);
-              if (uuid === truncateBeforeUuid) {
-                foundTruncationPoint = true;
-                continue;
-              }
-              userIndex++;
-            }
-          }
-        } catch { /* keep line anyway */ }
-
-        if (!foundTruncationPoint) {
-          outputLines.push(line);
-        }
-      }
-
-      await writeFile(newPath, outputLines.join('\n') + '\n', 'utf-8');
+    const originalPath = findCodexSessionFile(codexSessionId);
+    if (!originalPath) throw new Error(`Codex session file not found for: ${codexSessionId}`);
+    const { threadId, targetTurnId } = readForkSource(await readCodexSessionContent(originalPath), truncateBeforeUuid);
+    // Old Happy copies kept the source ID inside a renamed rollout. Do not silently fork the original instead.
+    if (!basename(originalPath).endsWith(`-${threadId}.jsonl`)) {
+      throw new Error('Codex session file does not match its thread id; copy the original session again');
     }
 
-    logger.debug(`[CodexSessionFork] Forked ${basename(originalPath)} -> ${basename(newPath)}`);
-    return { success: true, newFilePath: newPath };
+    peer = new CodexJsonRpcPeer();
+    await peer.spawn('npx', ['-y', CODEX_PACKAGE, 'app-server'], { cwd: process.cwd() });
+    await peer.request(Methods.INITIALIZE, {
+      clientInfo: { name: 'happy-codex-fork', version: '1.0.0' },
+      capabilities: { experimentalApi: true },
+    } satisfies InitializeParams);
+    peer.notify(Methods.INITIALIZED);
+
+    const params: ThreadForkParams = { threadId, excludeTurns: true };
+    if (targetTurnId) params.lastTurnId = await findPreviousTurn(peer, threadId, targetTurnId);
+    const { thread } = await peer.request<ThreadForkResponse>(Methods.THREAD_FORK, params);
+    if (!thread.id || thread.id === threadId || !thread.path || !isAbsolute(thread.path) || thread.path === originalPath) {
+      throw new Error('Codex did not return an independent persisted fork');
+    }
+    if (!(await stat(thread.path)).isFile()) throw new Error('Codex fork rollout is not a file');
+
+    logger.debug(`[CodexSessionFork] Forked ${threadId} -> ${thread.id}`);
+    return { success: true, newFilePath: thread.path };
   } catch (error) {
-    try { await unlinkAsync(newPath); } catch { /* ignore */ }
     return {
       success: false,
       errorMessage: error instanceof Error ? error.message : 'Failed to fork Codex session',
     };
+  } finally {
+    await peer?.close();
   }
 }

--- a/packages/happy-cli/src/codex/utils/codexSessionReader.test.ts
+++ b/packages/happy-cli/src/codex/utils/codexSessionReader.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -114,5 +114,100 @@ describe('listCodexSessions', () => {
     const { readAllCodexSessionUserMessages } = await import('./codexSessionReader');
     const messages = await readAllCodexSessionUserMessages(sessionUuid);
     expect(messages.map((message) => message.content)).toEqual(['before compact', 'after compact']);
+  });
+
+  function createHistorySnapshot() {
+    const parentId = '11111111-2222-4333-8444-555555555555';
+    const forkId = 'aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee';
+    const sessions = join(codexHomeDir, 'sessions');
+    mkdirSync(sessions, { recursive: true });
+    const parentPath = join(sessions, `rollout-2026-09-01T00-00-00-${parentId}.jsonl`);
+    const forkPath = join(sessions, `rollout-2026-09-01T00-01-00-${forkId}.jsonl`);
+    const user = (text: string, ordinal: number) => ({ type: 'response_item', ordinal, timestamp: '2026-09-01T00:00:00.000Z', payload: { role: 'user', content: [{ type: 'input_text', text }] } });
+    const prefix = [
+      { type: 'session_meta', ordinal: 0, payload: { id: parentId, history_mode: 'paginated' } },
+      user('Question with multibyte text: \u4e2d\u6587', 1),
+    ].map(row => JSON.stringify(row)).join('\n') + '\n';
+    writeFileSync(parentPath, prefix + JSON.stringify(user('Later parent message', 2)) + '\n');
+    const forkMeta = {
+      type: 'session_meta', ordinal: 0,
+      payload: { id: forkId, history_mode: 'paginated', history_base: { thread_id: parentId, end_byte_offset: Buffer.byteLength(prefix), end_ordinal_exclusive: 2 } },
+    };
+    writeFileSync(forkPath, [forkMeta, user('Fork question', 1)].map(row => JSON.stringify(row)).join('\n') + '\n');
+    return { parentId, forkId, parentPath, forkPath, forkMeta, user };
+  }
+
+  it('reads a paginated parent at its byte snapshot boundary and preserves the fork identity', async () => {
+    const fixture = createHistorySnapshot();
+    const { readCodexSessionContent, readAllCodexSessionUserMessages } = await import('./codexSessionReader');
+    const content = await readCodexSessionContent(fixture.forkPath);
+    expect(JSON.parse(content.split('\n')[0]).payload.id).toBe(fixture.forkId);
+    expect(content).not.toContain('Later parent message');
+    const messages = await readAllCodexSessionUserMessages(fixture.forkId);
+    expect(messages.map(message => message.content)).toEqual(['Question with multibyte text: \u4e2d\u6587', 'Fork question']);
+    expect(messages[0].uuid).toBe((await readAllCodexSessionUserMessages(fixture.parentId))[0].uuid);
+  });
+
+  it('resolves nested forks without including later updates to either parent', async () => {
+    const fixture = createHistorySnapshot();
+    const secondId = 'bbbbbbbb-cccc-4ddd-8eee-ffffffffffff';
+    const secondPath = join(codexHomeDir, 'sessions', `rollout-2026-09-01T00-02-00-${secondId}.jsonl`);
+    const snapshotLength = readFileSync(fixture.forkPath).length;
+    writeFileSync(fixture.forkPath, readFileSync(fixture.forkPath, 'utf-8') + JSON.stringify(fixture.user('Later fork message', 2)) + '\n');
+    writeFileSync(secondPath, JSON.stringify({
+      ...fixture.forkMeta,
+      payload: { ...fixture.forkMeta.payload, id: secondId, history_base: { thread_id: fixture.forkId, end_byte_offset: snapshotLength } },
+    }) + '\n');
+    const { readAllCodexSessionUserMessages } = await import('./codexSessionReader');
+    expect((await readAllCodexSessionUserMessages(secondId)).map(message => message.content)).toEqual(['Question with multibyte text: \u4e2d\u6587', 'Fork question']);
+  });
+
+  it('can read inherited history after the parent was archived', async () => {
+    const fixture = createHistorySnapshot();
+    const archive = join(codexHomeDir, 'archived_sessions');
+    mkdirSync(archive);
+    renameSync(fixture.parentPath, join(archive, `rollout-2026-09-01T00-00-00-${fixture.parentId}.jsonl`));
+    const { readAllCodexSessionUserMessages } = await import('./codexSessionReader');
+    expect(await readAllCodexSessionUserMessages(fixture.forkId)).toHaveLength(2);
+  });
+
+  it('rejects cyclic ancestry instead of looping', async () => {
+    const fixture = createHistorySnapshot();
+    const metadata = { ...fixture.forkMeta, payload: { ...fixture.forkMeta.payload, history_base: { thread_id: fixture.forkId, end_byte_offset: 0 } } };
+    writeFileSync(fixture.forkPath, JSON.stringify(metadata) + '\n');
+    const { readCodexSessionContent } = await import('./codexSessionReader');
+    await expect(readCodexSessionContent(fixture.forkPath)).rejects.toThrow('ancestry');
+  });
+
+  it('rejects a truncated parent snapshot rather than returning incomplete history', async () => {
+    const fixture = createHistorySnapshot();
+    writeFileSync(fixture.parentPath, '');
+    const { readCodexSessionContent } = await import('./codexSessionReader');
+    await expect(readCodexSessionContent(fixture.forkPath)).rejects.toThrow('incomplete');
+  });
+
+  it('does not expand ancestry for legacy forks that already contain copied history', async () => {
+    const fixture = createHistorySnapshot();
+    writeFileSync(fixture.forkPath, [
+      { ...fixture.forkMeta, payload: { id: fixture.forkId, history_mode: 'legacy', forked_from_id: fixture.parentId } },
+      fixture.user('Already copied message', 1),
+    ].map(row => JSON.stringify(row)).join('\n') + '\n');
+    const { readAllCodexSessionUserMessages } = await import('./codexSessionReader');
+    expect((await readAllCodexSessionUserMessages(fixture.forkId)).map(message => message.content)).toEqual(['Already copied message']);
+  });
+
+  it('rejects a snapshot boundary in the middle of a record', async () => {
+    const fixture = createHistorySnapshot();
+    fixture.forkMeta.payload.history_base.end_byte_offset--;
+    writeFileSync(fixture.forkPath, JSON.stringify(fixture.forkMeta) + '\n');
+    const { readCodexSessionContent } = await import('./codexSessionReader');
+    await expect(readCodexSessionContent(fixture.forkPath)).rejects.toThrow('record boundary');
+  });
+
+  it('rejects missing parent history rather than silently returning only local fork messages', async () => {
+    const fixture = createHistorySnapshot();
+    rmSync(fixture.parentPath);
+    const { readCodexSessionContent } = await import('./codexSessionReader');
+    await expect(readCodexSessionContent(fixture.forkPath)).rejects.toThrow('parent history not found');
   });
 });

--- a/packages/happy-cli/src/codex/utils/codexSessionReader.ts
+++ b/packages/happy-cli/src/codex/utils/codexSessionReader.ts
@@ -17,6 +17,7 @@ import { readFile, stat as statFile } from 'node:fs/promises';
 import { basename, join } from 'node:path';
 import { createHash } from 'node:crypto';
 import { createInterface } from 'node:readline';
+import { z } from 'zod';
 import { logger } from '@/ui/logger';
 import {
   loadSessionMetadataCache,
@@ -61,6 +62,42 @@ export function findCodexSessionFile(codexSessionId: string): string | null {
   } catch {
     return null;
   }
+}
+
+const historyBaseSchema = z.object({
+  thread_id: z.string().uuid(),
+  end_byte_offset: z.number().int().nonnegative().safe(),
+});
+
+/** Read inherited paginated history at the immutable byte boundary recorded by Codex. */
+export async function readCodexSessionContent(filePath: string): Promise<string> {
+  return readCodexHistorySnapshot(filePath, new Set());
+}
+
+async function readCodexHistorySnapshot(filePath: string, ancestors: Set<string>, endByteOffset?: number): Promise<string> {
+  if (ancestors.has(filePath) || ancestors.size >= 100) throw new Error('Invalid Codex history ancestry');
+  const visited = new Set(ancestors).add(filePath);
+  const buffer = await readFile(filePath);
+  if (endByteOffset !== undefined && endByteOffset > buffer.length) throw new Error('Codex parent history snapshot is incomplete');
+  if (endByteOffset && buffer[endByteOffset - 1] !== 10) throw new Error('Codex parent history snapshot does not end at a record boundary');
+  const content = buffer.subarray(0, endByteOffset ?? buffer.length).toString('utf-8');
+  const lines = content.split('\n');
+  let metadata;
+  try { metadata = JSON.parse(lines[0]); } catch { return content; }
+  if (metadata?.type !== 'session_meta' || metadata.payload?.history_mode !== 'paginated' || !metadata.payload.history_base) {
+    return content;
+  }
+
+  const base = historyBaseSchema.parse(metadata.payload.history_base);
+  const parentPath = findCodexSessionFile(base.thread_id)
+    ?? collectFilesRecursive(join(getCodexHomeDir(), 'archived_sessions')).find(path => basename(path).endsWith(`-${base.thread_id}.jsonl`));
+  if (!parentPath) throw new Error(`Codex parent history not found: ${base.thread_id}`);
+  const inherited = await readCodexHistorySnapshot(parentPath, visited, base.end_byte_offset);
+  const inheritedLines = inherited.split('\n').filter(line => {
+    if (!line.trim()) return false;
+    try { return JSON.parse(line).type !== 'session_meta'; } catch { return true; }
+  });
+  return [lines[0], ...inheritedLines, ...lines.slice(1)].join('\n');
 }
 
 function collectFilesRecursive(dir: string, acc: string[] = []): string[] {
@@ -172,7 +209,7 @@ export async function readAllCodexSessionUserMessages(
 
   let content: string;
   try {
-    content = await readFile(filePath, 'utf-8');
+    content = await readCodexSessionContent(filePath);
   } catch (error) {
     logger.debug(`[CodexSessionReader] Failed to read file: ${filePath}`, error);
     return [];
@@ -238,7 +275,7 @@ interface CodexSessionMetadataCacheEntry {
   gitBranch?: string | null;
 }
 
-const CODEX_SESSION_METADATA_CACHE_VERSION = 1;
+const CODEX_SESSION_METADATA_CACHE_VERSION = 2;
 const CODEX_SESSION_METADATA_CACHE_FILENAME = 'codex-session-metadata-cache.json';
 
 export async function saveCodexSessionCacheStats(sessionCache: SessionCacheRuntimeStats): Promise<void> {
@@ -267,6 +304,7 @@ async function parseCodexSessionMetadata(filePath: string): Promise<Omit<CodexSe
   let gitBranch: string | null = null;
   let title: string | null = null;
   let messageCount = 0;
+  let hasInheritedHistory = false;
 
   try {
     for await (const line of rl) {
@@ -276,6 +314,7 @@ async function parseCodexSessionMetadata(filePath: string): Promise<Omit<CodexSe
 
         if (parsed.type === 'session_meta') {
           const payload = parsed.payload;
+          hasInheritedHistory = payload?.history_mode === 'paginated' && !!payload.history_base;
           sessionId = typeof payload?.id === 'string' ? payload.id : null;
           originalPath = typeof payload?.cwd === 'string' ? payload.cwd : null;
           gitBranch = typeof payload?.git?.branch === 'string' ? payload.git.branch : null;
@@ -313,6 +352,11 @@ async function parseCodexSessionMetadata(filePath: string): Promise<Omit<CodexSe
   }
 
   const rawSessionId = fileSessionId || sessionId;
+  if (hasInheritedHistory && rawSessionId) {
+    const messages = await readAllCodexSessionUserMessages(rawSessionId);
+    messageCount = messages.length;
+    title = messages[0] ? normalizeSessionTitle(messages[0].content) : null;
+  }
   const displaySessionId = rawSessionId ? extractDisplaySessionId(rawSessionId) : null;
   if (!displaySessionId || messageCount === 0) {
     return null;
@@ -454,7 +498,7 @@ export async function getCodexSessionPreview(
 
   let content: string;
   try {
-    content = await readFile(filePath, 'utf-8');
+    content = await readCodexSessionContent(filePath);
   } catch {
     return [];
   }


### PR DESCRIPTION
Preserve paginated history snapshots when reading, backfilling and duplicating sessions. Reject unsupported truncation boundaries and add unit and native app-server regression coverage.

## Summary

Brief description of what this PR does.

## Changes

- ...

## Testing

How was this tested?

- [ ] Tested locally
- [ ] Existing tests pass
- [ ] New tests added (if applicable)

## Related issues

Closes #
