### PR TITLE
feat(codex): synchronize native archive with existing session actions

### DIFF
--- a/packages/happy-app/sources/-session/SessionView.tsx
+++ b/packages/happy-app/sources/-session/SessionView.tsx
@@ -33,6 +33,7 @@ import { handleImagePasteEvent } from '@/utils/imagePaste';
 import { isRunningOnMac } from '@/utils/platform';
 import { useDeviceType, useIsLandscape, useIsTablet } from '@/utils/responsive';
 import { formatPathRelativeToHome, generateCopyTitle, getSessionAvatarId, getSessionName, useSessionStatus, copySessionMetadata, copySessionModeSettings } from '@/utils/sessionUtils';
+import { canEditSession, canForkSession } from '@/utils/sessionLifecycle';
 import { getNativeHeaderTitleWidth } from '@/utils/nativeHeaderTitleWidth';
 import { isVersionSupported, useLatestCliVersion } from '@/utils/versionUtils';
 import { log } from '@/log';
@@ -577,6 +578,7 @@ function SessionViewLoaded({ sessionId, session }: { sessionId: string, session:
 
     // Handle opening the duplicate sheet - loads user messages from the session
     const handleOpenDuplicateSheet = React.useCallback(async () => {
+        if (!canForkSession(storage.getState().sessions[session.id])) return;
         const flavor = session.metadata?.flavor;
         const claudeSessionId = session.metadata?.claudeSessionId;
         const codexSessionId = session.metadata?.codexSessionId;
@@ -604,7 +606,7 @@ function SessionViewLoaded({ sessionId, session }: { sessionId: string, session:
         } finally {
             setDuplicateLoading(false);
         }
-    }, [machineId, session.metadata?.flavor, session.metadata?.claudeSessionId, session.metadata?.codexSessionId, loadDuplicateMessagesPage, applyDuplicatePage]);
+    }, [machineId, session.id, session.metadata?.flavor, session.metadata?.claudeSessionId, session.metadata?.codexSessionId, loadDuplicateMessagesPage, applyDuplicatePage]);
 
     const handleLoadMoreDuplicateMessages = React.useCallback(async () => {
         if (duplicateLoadingMore || !duplicateHasMore || duplicateBeforeIndex == null) return;
@@ -629,6 +631,10 @@ function SessionViewLoaded({ sessionId, session }: { sessionId: string, session:
     // write (AI-message forks continue after the reply, so there's nothing to
     // pre-fill; user-message forks pre-fill the tapped prompt).
     const forkSessionFromUuid = React.useCallback(async (opts: { uuid: string | null; draftText?: string; skipDraft: boolean }) => {
+        if (!canForkSession(storage.getState().sessions[session.id])) {
+            setDuplicateConfirming(false);
+            return;
+        }
         const { uuid, draftText, skipDraft } = opts;
         const flavor = session.metadata?.flavor;
         const claudeSessionId = session.metadata?.claudeSessionId;
@@ -729,6 +735,7 @@ function SessionViewLoaded({ sessionId, session }: { sessionId: string, session:
     // Handle selecting a message in the duplicate sheet. Picker rows are previews,
     // so fetch the full prompt by UUID before creating the new-session draft.
     const handleDuplicateSelect = React.useCallback(async (uuid: string) => {
+        if (!canForkSession(storage.getState().sessions[session.id])) return;
         const flavor = session.metadata?.flavor;
         const claudeSessionId = session.metadata?.claudeSessionId;
         const codexSessionId = session.metadata?.codexSessionId;
@@ -775,6 +782,7 @@ function SessionViewLoaded({ sessionId, session }: { sessionId: string, session:
     // (so the reply is kept); when the reply has no following prompt it's null,
     // meaning fork the whole session with no truncation.
     const performForkFromMessage = React.useCallback(async (request: ForkMessageRequest) => {
+        if (!canForkSession(storage.getState().sessions[session.id])) return;
         const flavor = session.metadata?.flavor;
         const claudeSessionId = session.metadata?.claudeSessionId;
         const codexSessionId = session.metadata?.codexSessionId;
@@ -826,6 +834,7 @@ function SessionViewLoaded({ sessionId, session }: { sessionId: string, session:
     // Handle the per-message fork icon: show the confirm dialog immediately,
     // then do the network work in performForkFromMessage once confirmed.
     const handleForkFromMessage = React.useCallback((request: ForkMessageRequest) => {
+        if (!canForkSession(storage.getState().sessions[session.id])) return;
         const flavor = session.metadata?.flavor;
         const claudeSessionId = session.metadata?.claudeSessionId;
         const codexSessionId = session.metadata?.codexSessionId;
@@ -846,7 +855,7 @@ function SessionViewLoaded({ sessionId, session }: { sessionId: string, session:
                 { text: t('duplicate.confirm'), onPress: () => { performForkFromMessage(request); } },
             ]
         );
-    }, [machineId, session.metadata?.flavor, session.metadata?.claudeSessionId, session.metadata?.codexSessionId, performForkFromMessage]);
+    }, [machineId, session.id, session.metadata?.flavor, session.metadata?.claudeSessionId, session.metadata?.codexSessionId, performForkFromMessage]);
 
     // Handle closing the duplicate sheet (prevent closing while confirming)
     const handleCloseDuplicateSheet = React.useCallback(() => {
@@ -1025,7 +1034,7 @@ function SessionViewLoaded({ sessionId, session }: { sessionId: string, session:
                     <ChatList
                         session={session}
                         onFillInput={handleFillInput}
-                        onForkMessage={handleForkFromMessage}
+                        onForkMessage={canForkSession(session) ? handleForkFromMessage : undefined}
                         forkingMessageId={forkingMessageId}
                         onLoadMore={handleLoadMore}
                         minimapCachedUserMessages={minimapCachedUserMessages}
@@ -1047,7 +1056,7 @@ function SessionViewLoaded({ sessionId, session }: { sessionId: string, session:
         </>
     ) : null;
 
-    const canEdit = !session.accessLevel || session.accessLevel !== 'view';
+    const canEdit = canEditSession(session);
 
     const handleSendNowPending = React.useCallback(async (pendingId: string) => {
         try {
@@ -1367,7 +1376,7 @@ function SessionViewLoaded({ sessionId, session }: { sessionId: string, session:
 
             {/* Duplicate Sheet */}
             <DuplicateSheet
-                visible={duplicateSheetVisible}
+                visible={canForkSession(session) && duplicateSheetVisible}
                 messages={duplicateMessages}
                 loading={duplicateLoading}
                 loadingMore={duplicateLoadingMore}

--- a/packages/happy-app/sources/-session/SessionView.visibility.test.ts
+++ b/packages/happy-app/sources/-session/SessionView.visibility.test.ts
@@ -1,0 +1,48 @@
+import { readFileSync } from 'node:fs';
+import ts from 'typescript';
+import { describe, expect, it } from 'vitest';
+import type { Session } from '@/sync/storageTypes';
+import { canForkSession } from '@/utils/sessionLifecycle';
+
+// Exercise the actual JSX prop without loading the native screen's dependencies.
+const source = ts.createSourceFile('SessionView.tsx',
+    readFileSync(new URL('./SessionView.tsx', import.meta.url), 'utf8'),
+    ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX);
+const expressions: string[] = [];
+function visit(node: ts.Node): void {
+    if (ts.isJsxSelfClosingElement(node) && node.tagName.getText(source) === 'DuplicateSheet') {
+        for (const prop of node.attributes.properties) {
+            if (ts.isJsxAttribute(prop) && prop.name.getText(source) === 'visible' &&
+                prop.initializer && ts.isJsxExpression(prop.initializer) && prop.initializer.expression) {
+                expressions.push(prop.initializer.expression.getText(source));
+            }
+        }
+    }
+    ts.forEachChild(node, visit);
+}
+visit(source);
+
+function visible(session: Session, duplicateSheetVisible: boolean): boolean {
+    expect(expressions).toHaveLength(1);
+    return new Function('session', 'duplicateSheetVisible', 'canForkSession',
+        `return (${expressions[0]});`)(session, duplicateSheetVisible, canForkSession);
+}
+
+describe('SessionView duplicate sheet visibility', () => {
+    it.each([undefined, 'running'])('opens offline sessions with lifecycle %s and survives heartbeat expiry', lifecycleState => {
+        const session = { active: false, metadata: { lifecycleState } } as Session;
+        expect(visible(session, true)).toBe(true);
+        expect(visible(session, false)).toBe(false);
+        session.active = true;
+        expect(visible(session, true)).toBe(true);
+        session.active = false;
+        expect(visible(session, true)).toBe(true);
+        session.metadata!.lifecycleState = 'archived';
+        expect(visible(session, true)).toBe(false);
+    });
+
+    it.each([true, false])('hides explicitly archived sessions when active is %s', active => {
+        const session = { active, metadata: { lifecycleState: 'archived' } } as Session;
+        expect(visible(session, true)).toBe(false);
+    });
+});

--- a/packages/happy-app/sources/app/(app)/session/[id]/info.tsx
+++ b/packages/happy-app/sources/app/(app)/session/[id]/info.tsx
@@ -10,11 +10,12 @@ import { ItemList } from '@/components/ItemList';
 import { Avatar } from '@/components/Avatar';
 import { useSession, useIsDataReady, useMachine, useOrchestratorHasRuns, storage } from '@/sync/storage';
 import { generateCopyTitle, getSessionName, useSessionStatus, formatOSPlatform, formatPathRelativeToHome, getSessionAvatarId, copySessionMetadata, copySessionModeSettings } from '@/utils/sessionUtils';
+import { canArchiveSession } from '@/utils/sessionLifecycle';
 import * as Clipboard from 'expo-clipboard';
 import { Modal } from '@/modal';
 import { hapticsLight } from '@/components/haptics';
 import { showCopiedToast } from '@/components/Toast';
-import { sessionKill, sessionDelete, machineForkClaudeSession, machineForkGeminiSession, machineForkCodexSession, machineSpawnNewSession, sessionUpdateSummary, sessionUpdateMetadataFields } from '@/sync/ops';
+import { sessionArchive, sessionKill, sessionDelete, machineForkClaudeSession, machineForkGeminiSession, machineForkCodexSession, machineSpawnNewSession, sessionUpdateSummary, sessionUpdateMetadataFields } from '@/sync/ops';
 import { leaveSharedSession } from '@/sync/apiSharing';
 import { pushWorktreeBranch, mergeWorktreeBranch, createWorktreePR, cleanupWorktree, cleanupWorkspace, getLocalBranches, getCurrentBranch } from '@/utils/worktreeOps';
 import { getWorkspaceRepos } from '@/utils/workspaceRepos';
@@ -209,7 +210,7 @@ function SessionInfoContent({ session }: { session: Session }) {
         const previousActive = storage.getState().sessions[session.id]?.active ?? session.active;
         storage.getState().updateSessionActivity(session.id, false);
 
-        const result = await sessionKill(session.id);
+        const result = await sessionArchive(session.id);
         const errorMessage = result.message || t('sessionInfo.failedToArchiveSession');
 
         // Archiving is idempotent: if RPC target is gone, session is effectively already archived.
@@ -225,6 +226,7 @@ function SessionInfoContent({ session }: { session: Session }) {
         }
 
         await sync.clearSessionMessageCache(session.id);
+        if (result.nativeArchiveError) throw new HappyError(t('sessionInfo.codexArchiveFailed') + ': ' + result.nativeArchiveError, false);
 
         // Success - navigate back
         navigateAfterArchive();
@@ -381,7 +383,7 @@ function SessionInfoContent({ session }: { session: Session }) {
                 resumeSessionId = forkResult.newSessionId;
                 agent = 'gemini';
             } else if (flavor === 'codex' && codexSessionId) {
-                const forkResult = await machineForkCodexSession(machineId, codexSessionId);
+                const forkResult = await machineForkCodexSession(machineId, codexSessionId, { restoreArchived: !isOnline });
                 if (!forkResult.success || !forkResult.newFilePath) {
                     Modal.alert(t('common.error'), forkResult.errorMessage || t('claudeHistory.resumeFailed'));
                     return;
@@ -1047,7 +1049,7 @@ function SessionInfoContent({ session }: { session: Session }) {
                                 showChevron={!forkingSession}
                             />
                         )}
-                        {isOwner && sessionStatus.isConnected && (
+                        {canArchiveSession(session, sessionStatus.isConnected) && (
                             <Item
                                 title={t('sessionInfo.archiveSession')}
                                 subtitle={t('sessionInfo.archiveSessionSubtitle')}

--- a/packages/happy-app/sources/app/(app)/session/recent.tsx
+++ b/packages/happy-app/sources/app/(app)/session/recent.tsx
@@ -482,7 +482,7 @@ function SessionHistory() {
                 resumeSessionId = forkResult.newSessionId;
                 agent = 'gemini';
             } else if (flavor === 'codex' && codexSessionId) {
-                const forkResult = await machineForkCodexSession(machineId, codexSessionId);
+                const forkResult = await machineForkCodexSession(machineId, codexSessionId, { restoreArchived: mode !== 'copy' });
                 if (!forkResult.success || !forkResult.newFilePath) {
                     Modal.alert(t('common.error'), forkResult.errorMessage || t('claudeHistory.resumeFailed'));
                     return;

--- a/packages/happy-app/sources/components/ActiveSessionsGroup.tsx
+++ b/packages/happy-app/sources/components/ActiveSessionsGroup.tsx
@@ -12,7 +12,7 @@ import { StatusDot } from './StatusDot';
 import { useOrchestratorRunningTaskCount, useSetting, useSessionHasDraft } from '@/sync/storage';
 import { StyleSheet } from 'react-native-unistyles';
 import { isMachineOnline } from '@/utils/machineUtils';
-import { machineSpawnNewSession, sessionKill } from '@/sync/ops';
+import { machineSpawnNewSession, sessionArchive } from '@/sync/ops';
 import { storage } from '@/sync/storage';
 import { Modal } from '@/modal';
 import { ProjectGitStatus } from './ProjectGitStatus';
@@ -382,7 +382,7 @@ const CompactSessionRow = React.memo(({ session, selected, showBorder, registerS
         const previousActive = storage.getState().sessions[session.id]?.active ?? session.active;
         storage.getState().updateSessionActivity(session.id, false);
 
-        const result = await sessionKill(session.id);
+        const result = await sessionArchive(session.id);
         const errorMessage = result.message || t('sessionInfo.failedToArchiveSession');
 
         if (!result.success && /RPC method not available/i.test(errorMessage)) {
@@ -396,6 +396,7 @@ const CompactSessionRow = React.memo(({ session, selected, showBorder, registerS
         }
 
         await sync.clearSessionMessageCache(session.id);
+        if (result.nativeArchiveError) throw new HappyError(t('sessionInfo.codexArchiveFailed') + ': ' + result.nativeArchiveError, false);
     });
 
     const [archiveMenuVisible, setArchiveMenuVisible] = React.useState(false);

--- a/packages/happy-app/sources/components/ActiveSessionsGroupCompact.tsx
+++ b/packages/happy-app/sources/components/ActiveSessionsGroupCompact.tsx
@@ -12,7 +12,7 @@ import { StatusDot } from './StatusDot';
 import { useSetting, useSessionHasDraft } from '@/sync/storage';
 import { StyleSheet, useUnistyles } from 'react-native-unistyles';
 import { isMachineOnline } from '@/utils/machineUtils';
-import { machineSpawnNewSession, sessionKill } from '@/sync/ops';
+import { machineSpawnNewSession, sessionArchive } from '@/sync/ops';
 import { resolveAbsolutePath } from '@/utils/pathUtils';
 import { storage } from '@/sync/storage';
 import { Modal } from '@/modal';
@@ -349,7 +349,7 @@ const CompactSessionRow = React.memo(({ session, selected, showBorder, registerS
         const previousActive = storage.getState().sessions[session.id]?.active ?? session.active;
         storage.getState().updateSessionActivity(session.id, false);
 
-        const result = await sessionKill(session.id);
+        const result = await sessionArchive(session.id);
         const errorMessage = result.message || t('sessionInfo.failedToArchiveSession');
 
         if (!result.success && /RPC method not available/i.test(errorMessage)) {
@@ -363,6 +363,7 @@ const CompactSessionRow = React.memo(({ session, selected, showBorder, registerS
         }
 
         await sync.clearSessionMessageCache(session.id);
+        if (result.nativeArchiveError) throw new HappyError(t('sessionInfo.codexArchiveFailed') + ': ' + result.nativeArchiveError, false);
     });
 
     const [archiveMenuVisible, setArchiveMenuVisible] = React.useState(false);

--- a/packages/happy-app/sources/components/SessionContextMenu.tsx
+++ b/packages/happy-app/sources/components/SessionContextMenu.tsx
@@ -23,7 +23,7 @@ import {
     machineForkGeminiSession,
     machineSpawnNewSession,
     sessionDelete,
-    sessionKill,
+    sessionArchive,
 } from '@/sync/ops';
 import { cleanupWorkspace, cleanupWorktree } from '@/utils/worktreeOps';
 import { getWorkspaceRepos } from '@/utils/workspaceRepos';
@@ -98,7 +98,7 @@ function useSessionQuickActions(session: Session) {
     const [, performArchive] = useHappyAction(async () => {
         const previousActive = storage.getState().sessions[session.id]?.active ?? session.active;
         storage.getState().updateSessionActivity(session.id, false);
-        const result = await sessionKill(session.id);
+        const result = await sessionArchive(session.id);
         const errorMessage = result.message || t('sessionInfo.failedToArchiveSession');
         if (!result.success && /RPC method not available/i.test(errorMessage)) {
             await sync.clearSessionMessageCache(session.id);
@@ -109,6 +109,7 @@ function useSessionQuickActions(session: Session) {
             throw new HappyError(errorMessage, false);
         }
         await sync.clearSessionMessageCache(session.id);
+        if (result.nativeArchiveError) throw new HappyError(t('sessionInfo.codexArchiveFailed') + ': ' + result.nativeArchiveError, false);
     });
 
     const [, performDelete] = useHappyAction(async () => {
@@ -228,7 +229,7 @@ function useSessionQuickActions(session: Session) {
                 resumeSessionId = forkResult.newSessionId;
                 agent = 'gemini';
             } else if (flavor === 'codex' && codexSessionId) {
-                const forkResult = await machineForkCodexSession(machineId, codexSessionId);
+                const forkResult = await machineForkCodexSession(machineId, codexSessionId, { restoreArchived: !session.active });
                 if (!forkResult.success || !forkResult.newFilePath) {
                     Modal.alert(t('common.error'), forkResult.errorMessage || t('claudeHistory.resumeFailed'));
                     return;

--- a/packages/happy-app/sources/components/sessionQuickActions.test.ts
+++ b/packages/happy-app/sources/components/sessionQuickActions.test.ts
@@ -51,4 +51,21 @@ describe('getSessionQuickActionKinds', () => {
             isConnected: true,
         })).toEqual(['details', 'newSession', 'leaveSharedSession']);
     });
+
+    it('retains native archive after stopping Codex and rebuilding the menu', () => {
+        const current = session();
+        current.metadata = { ...current.metadata!, flavor: 'codex', codexSessionId: 'native-1' };
+        expect(getSessionQuickActionKinds({ session: current, hasOrchestratorRuns: false, isConnected: true })).toContain('archiveSession');
+        current.active = false;
+        current.metadata.lifecycleState = 'archived';
+        const actions = getSessionQuickActionKinds({ session: current, hasOrchestratorRuns: false, isConnected: false });
+        expect(actions).toContain('archiveSession');
+        expect(actions).toContain('deleteSession');
+    });
+
+    it.each(['view', 'edit', 'admin'] as const)('does not offer native retry to shared %s users', accessLevel => {
+        const current = session({ active: false, accessLevel });
+        current.metadata = { ...current.metadata!, flavor: 'codex' };
+        expect(getSessionQuickActionKinds({ session: current, hasOrchestratorRuns: false, isConnected: false })).not.toContain('archiveSession');
+    });
 });

--- a/packages/happy-app/sources/components/sessionQuickActions.ts
+++ b/packages/happy-app/sources/components/sessionQuickActions.ts
@@ -1,4 +1,5 @@
 import { Session } from '@/sync/storageTypes';
+import { canArchiveSession } from '@/utils/sessionLifecycle';
 
 export type SessionQuickActionKind =
     | 'details'
@@ -34,7 +35,7 @@ export function getSessionQuickActionKinds({
     if (!isOwner) actions.push('leaveSharedSession');
     if (isOwner && session.metadata?.machineId) actions.push('viewMachine');
     if (isOwner && isForkable) actions.push('forkSession');
-    if (isOwner && isConnected) actions.push('archiveSession');
+    if (canArchiveSession(session, isConnected)) actions.push('archiveSession');
     if (isOwner && !isConnected && !session.active) actions.push('deleteSession');
     return actions;
 }

--- a/packages/happy-app/sources/sync/ops.archive.test.ts
+++ b/packages/happy-app/sources/sync/ops.archive.test.ts
@@ -1,0 +1,175 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({ getState: vi.fn(), sessionRPC: vi.fn(), machineRPC: vi.fn(), request: vi.fn(),
+    emitWithAck: vi.fn(), encryptRaw: vi.fn(), decryptRaw: vi.fn(), getSessionEncryption: vi.fn() }));
+vi.mock('./apiSocket', () => ({ apiSocket: mocks }));
+vi.mock('./sync', () => ({ sync: { encryption: { getSessionEncryption: mocks.getSessionEncryption } } }));
+vi.mock('./storage', () => ({ storage: { getState: mocks.getState } }));
+import { sessionArchive, sessionKill, machineForkCodexSession, machineDuplicateCodexSession } from './ops';
+import { getSessionQuickActionKinds } from '@/components/sessionQuickActions';
+import { canArchiveSession, canEditSession, canForkSession } from '@/utils/sessionLifecycle';
+import type { Session } from './storageTypes';
+
+describe('stop-based archive with Codex native synchronization', () => {
+    beforeEach(() => {
+        vi.resetAllMocks();
+        mocks.getState.mockReturnValue({ sessions: { s1: { metadataVersion: 4, metadata: { flavor: 'codex', machineId: 'm1', codexSessionId: 'native-1', lifecycleState: 'running' } } } });
+        mocks.sessionRPC.mockResolvedValue({ success: true });
+        mocks.machineRPC.mockResolvedValue({ success: true, stopped: true });
+        mocks.getSessionEncryption.mockReturnValue({ encryptRaw: mocks.encryptRaw, decryptRaw: mocks.decryptRaw });
+        mocks.encryptRaw.mockImplementation(async value => JSON.stringify(value));
+        mocks.decryptRaw.mockImplementation(async value => JSON.parse(value));
+        mocks.emitWithAck.mockResolvedValue({ result: 'success', version: 5 });
+    });
+
+    it('stops first, then archives through the machine without a server archive endpoint', async () => {
+        expect(await sessionArchive('s1')).toEqual({ success: true });
+        expect(mocks.sessionRPC).toHaveBeenCalledWith('s1', 'killSession', {});
+        expect(mocks.machineRPC).toHaveBeenCalledWith('m1', 'codex-archive-session', { sessionId: 's1', nativeSessionId: 'native-1' }, 120_000);
+        expect(mocks.sessionRPC.mock.invocationCallOrder[0]).toBeLessThan(mocks.machineRPC.mock.invocationCallOrder[0]);
+        expect(mocks.request).not.toHaveBeenCalled();
+    });
+
+    it.each(['claude', 'gemini'])('keeps the existing %s archive behavior', async flavor => {
+        mocks.getState.mockReturnValue({ sessions: { s1: { metadata: { flavor } } } });
+        expect(await sessionArchive('s1')).toEqual({ success: true });
+        expect(mocks.machineRPC).not.toHaveBeenCalled();
+    });
+
+    it('does not add native side effects to ordinary stop operations', async () => {
+        await sessionKill('s1');
+        expect(mocks.machineRPC).not.toHaveBeenCalled();
+    });
+
+    it('can retry native archive after the session RPC has exited', async () => {
+        mocks.sessionRPC.mockRejectedValue(new Error('RPC method not available'));
+        expect(await sessionArchive('s1')).toEqual({ success: true });
+        expect(mocks.machineRPC).toHaveBeenCalledOnce();
+        const current = mocks.getState().sessions.s1 as Session;
+        expect(mocks.emitWithAck).toHaveBeenCalledWith('update-metadata', {
+            sid: 's1', expectedVersion: 4,
+            metadata: JSON.stringify({ ...current.metadata, lifecycleState: 'archived' }),
+        });
+        expect(mocks.machineRPC.mock.invocationCallOrder[0]).toBeLessThan(mocks.emitWithAck.mock.invocationCallOrder[0]);
+        // Apply the persisted metadata as received through session synchronization.
+        current.metadata = await mocks.decryptRaw(mocks.emitWithAck.mock.calls[0][1].metadata);
+        expect(canEditSession(current)).toBe(false);
+        expect(canForkSession(current)).toBe(false);
+    });
+
+    it('retries lifecycle persistence without overwriting concurrent metadata changes', async () => {
+        const latest = { ...mocks.getState().sessions.s1.metadata, name: 'updated elsewhere' };
+        mocks.emitWithAck.mockResolvedValueOnce({ result: 'version-mismatch', version: 6, metadata: JSON.stringify(latest) });
+        expect(await sessionArchive('s1')).toEqual({ success: true });
+        expect(mocks.emitWithAck).toHaveBeenLastCalledWith('update-metadata', {
+            sid: 's1', expectedVersion: 6, metadata: JSON.stringify({ ...latest, lifecycleState: 'archived' }),
+        });
+    });
+
+    it.each([true, false])('preserves the confirmed stop on metadata failure with session RPC success %s', async success => {
+        mocks.sessionRPC.mockResolvedValue({ success, message: 'RPC method not available' });
+        mocks.emitWithAck.mockRejectedValue(new Error('Disconnected'));
+        expect(await sessionArchive('s1')).toEqual({ success: true, nativeArchiveError: 'archive-metadata-update-failed: Disconnected' });
+    });
+
+    it.each([true, false])('preserves the confirmed target stop when another session uses its native thread (session RPC success %s)', async success => {
+        mocks.sessionRPC.mockResolvedValue({ success, message: 'RPC method not available' });
+        mocks.machineRPC.mockResolvedValue({ success: false, stopped: true, error: 'native-session-in-use' });
+        expect(await sessionArchive('s1')).toEqual({ success: true, nativeArchiveError: 'native-session-in-use' });
+        expect(mocks.emitWithAck).not.toHaveBeenCalled();
+    });
+
+    it('does not archive after an unacknowledged stop failure', async () => {
+        mocks.sessionRPC.mockRejectedValue(new Error('Disconnected'));
+        expect(await sessionArchive('s1')).toEqual({ success: false, message: 'Disconnected' });
+        expect(mocks.machineRPC).not.toHaveBeenCalled();
+    });
+
+    it.each(['session-identity-unavailable', 'session-provider-mismatch', 'native-session-id-unavailable'])('keeps an acknowledged stop when native archive reports %s', async error => {
+        mocks.machineRPC.mockResolvedValue({ success: false, stopped: false, error });
+        expect(await sessionArchive('s1')).toEqual({ success: true, nativeArchiveError: error });
+    });
+
+    it.each(['session-identity-unavailable', 'session-provider-mismatch', 'native-session-id-unavailable'])('requires stop confirmation when native archive reports %s', async error => {
+        mocks.sessionRPC.mockRejectedValue(new Error('RPC method not available'));
+        mocks.machineRPC.mockResolvedValue({ success: false, stopped: false, error });
+        expect(await sessionArchive('s1')).toEqual({ success: false, message: error });
+    });
+
+    it.each([true, false])('preserves daemon stop rejection when session stop success is %s', async success => {
+        mocks.sessionRPC.mockResolvedValue({ success, message: 'RPC method not available' });
+        for (const error of ['native-session-in-use', 'stop-not-confirmed', 'stop-failed', 'process-verification-unsupported', 'unknown-error']) {
+            mocks.machineRPC.mockResolvedValue({ success: false, stopped: false, error });
+            expect(await sessionArchive('s1')).toEqual({ success: false, message: error });
+        }
+    });
+
+    it.each(['daemon offline', 'RPC timeout', 'RPC method not available'])('fails without stop confirmation when daemon reports %s', async message => {
+        mocks.sessionRPC.mockRejectedValue(new Error('RPC method not available'));
+        mocks.machineRPC.mockRejectedValue(new Error(message));
+        expect(await sessionArchive('s1')).toEqual({ success: false, message: message === 'RPC method not available' ? 'daemon-rpc-unavailable' : message });
+    });
+
+    it('does not infer stop confirmation from a legacy daemon response', async () => {
+        mocks.sessionRPC.mockRejectedValue(new Error('RPC method not available'));
+        mocks.machineRPC.mockResolvedValue({ success: true });
+        expect(await sessionArchive('s1')).toEqual({ success: false, message: 'stop-not-confirmed' });
+    });
+
+    it('warns on native failure when only the daemon confirmed the stop', async () => {
+        mocks.sessionRPC.mockRejectedValue(new Error('RPC method not available'));
+        mocks.machineRPC.mockResolvedValue({ success: false, stopped: true, error: 'native-archive-failed' });
+        expect(await sessionArchive('s1')).toEqual({ success: true, nativeArchiveError: 'native-archive-failed' });
+    });
+
+    it('reports native failure separately without rolling back the stop', async () => {
+        mocks.machineRPC.mockResolvedValue({ success: false, stopped: true, error: 'native-archive-failed' });
+        expect(await sessionArchive('s1')).toEqual({ success: true, nativeArchiveError: 'native-archive-failed' });
+    });
+
+    it.each(['daemon offline', 'RPC timeout'])('keeps both retry entries usable after %s, without restoring the session', async error => {
+        const current = mocks.getState().sessions.s1 as Session;
+        current.active = true;
+        mocks.machineRPC.mockRejectedValueOnce(new Error(error));
+        expect(await sessionArchive('s1')).toEqual({ success: true, nativeArchiveError: error });
+
+        current.active = false;
+        current.metadata!.lifecycleState = 'archived';
+        expect(canArchiveSession(current, false)).toBe(true);
+        expect(getSessionQuickActionKinds({ session: current, hasOrchestratorRuns: false, isConnected: false })).toContain('archiveSession');
+
+        mocks.sessionRPC.mockRejectedValue(new Error('RPC method not available'));
+        expect(await sessionArchive('s1')).toEqual({ success: true });
+        expect(current.active).toBe(false);
+        expect(mocks.machineRPC).toHaveBeenCalledTimes(2);
+        for (const call of mocks.machineRPC.mock.calls) {
+            expect(call[1]).toBe('codex-archive-session');
+        }
+    });
+
+    it('does not swallow an unavailable daemon RPC as native success', async () => {
+        mocks.machineRPC.mockRejectedValue(new Error('RPC method not available'));
+        expect(await sessionArchive('s1')).toEqual({ success: true, nativeArchiveError: 'RPC method not available' });
+    });
+
+    it('reports a missing machine after stopping', async () => {
+        mocks.getState.mockReturnValue({ sessions: { s1: { metadata: { flavor: 'codex' } } } });
+        expect(await sessionArchive('s1')).toEqual({ success: true, nativeArchiveError: 'machine-id-unavailable' });
+        expect(mocks.machineRPC).not.toHaveBeenCalled();
+    });
+
+    it('allows native restore to finish within the resume RPC timeout', async () => {
+        await machineForkCodexSession('m1', 'native-1', { restoreArchived: true });
+        expect(mocks.machineRPC).toHaveBeenCalledWith('m1', 'codex-fork-session', { codexSessionId: 'native-1', restoreArchived: true }, 120000);
+    });
+
+    it('does not request restoration for ordinary forks', async () => {
+        await machineForkCodexSession('m1', 'native-1');
+        expect(mocks.machineRPC).toHaveBeenCalledWith('m1', 'codex-fork-session', { codexSessionId: 'native-1', restoreArchived: undefined }, 120000);
+    });
+
+    it('passes caller timeouts through to the duplicate RPC', async () => {
+        await machineDuplicateCodexSession('m1', 'native-1', 'message-1', { timeoutMs: 45000 });
+        expect(mocks.machineRPC).toHaveBeenCalledWith('m1', 'codex-duplicate-session', { codexSessionId: 'native-1', truncateBeforeUuid: 'message-1' }, 45000);
+    });
+});

--- a/packages/happy-app/sources/sync/ops.ts
+++ b/packages/happy-app/sources/sync/ops.ts
@@ -5,6 +5,7 @@
 
 import { apiSocket } from './apiSocket';
 import { sync } from './sync';
+import { storage } from './storage';
 import type { MachineMetadata, Metadata } from './storageTypes';
 
 // Strict type definitions for all operations
@@ -911,6 +912,48 @@ export async function sessionKill(sessionId: string): Promise<SessionKillRespons
     }
 }
 
+/** Keep Happy's stop-based archive behavior, then synchronize Codex's native history. */
+export async function sessionArchive(sessionId: string): Promise<{ success: boolean; message?: string; nativeArchiveError?: string }> {
+    const metadata = storage.getState().sessions[sessionId]?.metadata;
+    const stopped = await sessionKill(sessionId);
+    if (metadata?.flavor !== 'codex') return stopped;
+    if (!stopped.success && !/RPC method not available/i.test(stopped.message ?? '')) return stopped;
+
+    // Native failures must not roll back Happy's stop or be mistaken for a missing session RPC.
+    try {
+        if (!metadata.machineId) throw new Error('machine-id-unavailable');
+        const result = await apiSocket.machineRPC<{ success: boolean; stopped?: boolean; error?: string }, { sessionId: string; nativeSessionId?: string }>(
+            metadata.machineId, 'codex-archive-session',
+            { sessionId, nativeSessionId: metadata.codexSessionId ?? undefined }, 120_000,
+        );
+        // Missing native identity prevents daemon archival, not an acknowledged session stop.
+        if (stopped.success && !result?.success && [
+            'session-identity-unavailable', 'session-provider-mismatch', 'native-session-id-unavailable',
+        ].includes(result?.error ?? '')) {
+            return { success: true, nativeArchiveError: result?.error };
+        }
+        if (result?.stopped === false || (!stopped.success && result?.stopped !== true)) {
+            return { success: false, message: result?.error ?? 'stop-not-confirmed' };
+        }
+        if (!result?.success) return { success: true, nativeArchiveError: result?.error ?? 'native-archive-failed' };
+        try {
+            const session = storage.getState().sessions[sessionId];
+            if (!session?.metadata) throw new Error('session-metadata-unavailable');
+            await sessionUpdateMetadataFields(sessionId, session.metadata, { lifecycleState: 'archived' }, session.metadataVersion);
+        } catch (error) {
+            // Native history has moved and the stop is confirmed; do not restore active state.
+            const message = error instanceof Error ? error.message : 'unknown-error';
+            return { success: true, nativeArchiveError: `archive-metadata-update-failed: ${message}` };
+        }
+        return { success: true };
+    } catch (error) {
+        const rawMessage = error instanceof Error ? error.message : 'native-archive-failed';
+        // Archive callers tolerate missing session RPCs, but not an unavailable daemon.
+        const message = !stopped.success && /RPC method not available/i.test(rawMessage) ? 'daemon-rpc-unavailable' : rawMessage;
+        return stopped.success ? { success: true, nativeArchiveError: message } : { success: false, message };
+    }
+}
+
 /**
  * Permanently delete a session from the server
  * This will remove the session and all its associated data (messages, usage reports, access keys)
@@ -1275,20 +1318,15 @@ export async function machineDuplicateCodexSession(
     truncateBeforeUuid: string,
     options?: { timeoutMs?: number }
 ): Promise<{ success: boolean; newFilePath?: string; errorMessage?: string }> {
-    const timeoutMs = options?.timeoutMs ?? 90000;
+    const timeoutMs = options?.timeoutMs ?? 120000;
 
     try {
-        const rpcPromise = apiSocket.machineRPC<any, { codexSessionId: string; truncateBeforeUuid: string }>(
+        const result = await apiSocket.machineRPC<any, { codexSessionId: string; truncateBeforeUuid: string }>(
             machineId,
             'codex-duplicate-session',
-            { codexSessionId, truncateBeforeUuid }
+            { codexSessionId, truncateBeforeUuid },
+            timeoutMs
         );
-
-        const timeoutPromise = new Promise<never>((_, reject) => {
-            setTimeout(() => reject(new Error('Request timed out')), timeoutMs);
-        });
-
-        const result = await Promise.race([rpcPromise, timeoutPromise]);
 
         if (!result) {
             return { success: false, errorMessage: 'RPC returned empty response' };
@@ -1315,22 +1353,17 @@ export async function machineDuplicateCodexSession(
 export async function machineForkCodexSession(
     machineId: string,
     codexSessionId: string,
-    options?: { timeoutMs?: number }
+    options?: { timeoutMs?: number; restoreArchived?: boolean }
 ): Promise<{ success: boolean; newFilePath?: string; errorMessage?: string }> {
-    const timeoutMs = options?.timeoutMs ?? 90000;
+    const timeoutMs = options?.timeoutMs ?? 120000;
 
     try {
-        const rpcPromise = apiSocket.machineRPC<any, { codexSessionId: string }>(
+        const result = await apiSocket.machineRPC<any, { codexSessionId: string; restoreArchived?: boolean }>(
             machineId,
             'codex-fork-session',
-            { codexSessionId }
+            { codexSessionId, restoreArchived: options?.restoreArchived },
+            timeoutMs
         );
-
-        const timeoutPromise = new Promise<never>((_, reject) => {
-            setTimeout(() => reject(new Error('Request timed out')), timeoutMs);
-        });
-
-        const result = await Promise.race([rpcPromise, timeoutPromise]);
 
         if (!result) {
             return { success: false, errorMessage: 'RPC returned empty response' };

--- a/packages/happy-app/sources/sync/storageTypes.ts
+++ b/packages/happy-app/sources/sync/storageTypes.ts
@@ -59,6 +59,10 @@ export const MetadataSchema = z.object({
     happyHomeDir: z.string().optional(), // Happy configuration directory 
     hostPid: z.number().optional(), // Process ID of the session
     flavor: z.string().nullish(), // Session flavor/variant identifier
+    lifecycleState: z.string().optional(),
+    lifecycleStateSince: z.number().optional(),
+    archivedBy: z.string().optional(),
+    archiveReason: z.string().optional(),
     isWorktree: z.boolean().optional(), // Whether this session uses a git worktree
     worktreeBasePath: z.string().optional(), // Original repository path before worktree
     worktreeBranchName: z.string().optional(), // Branch name created for the worktree

--- a/packages/happy-app/sources/text/_default.ts
+++ b/packages/happy-app/sources/text/_default.ts
@@ -963,6 +963,7 @@ export const en = {
         failedToCopyMetadata: 'Failed to copy metadata',
         failedToKillSession: 'Failed to kill session',
         failedToArchiveSession: 'Failed to archive session',
+        codexArchiveFailed: 'Codex native archive failed. The session may already be stopped. Retry archiving',
         colorMarker: 'Color Marker',
         clearColorMarker: 'Clear color marker',
         markerRed: 'Red marker',

--- a/packages/happy-app/sources/text/translations/ca.ts
+++ b/packages/happy-app/sources/text/translations/ca.ts
@@ -952,6 +952,7 @@ export const ca: TranslationStructure = {
         failedToCopyMetadata: 'Ha fallat copiar les metadades',
         failedToKillSession: 'Ha fallat finalitzar la sessió',
         failedToArchiveSession: 'Ha fallat arxivar la sessió',
+        codexArchiveFailed: 'Codex native archive failed. The session may already be stopped. Retry archiving',
         colorMarker: 'Marcador de color',
         clearColorMarker: 'Treu el marcador de color',
         markerRed: 'Marcador vermell',

--- a/packages/happy-app/sources/text/translations/en.ts
+++ b/packages/happy-app/sources/text/translations/en.ts
@@ -969,6 +969,7 @@ export const en: TranslationStructure = {
         failedToCopyMetadata: 'Failed to copy metadata',
         failedToKillSession: 'Failed to kill session',
         failedToArchiveSession: 'Failed to archive session',
+        codexArchiveFailed: 'Codex native archive failed. The session may already be stopped. Retry archiving',
         colorMarker: 'Color Marker',
         clearColorMarker: 'Clear color marker',
         markerRed: 'Red marker',

--- a/packages/happy-app/sources/text/translations/es.ts
+++ b/packages/happy-app/sources/text/translations/es.ts
@@ -952,6 +952,7 @@ export const es: TranslationStructure = {
         failedToCopyMetadata: 'Falló al copiar metadatos',
         failedToKillSession: 'Falló al terminar sesión',
         failedToArchiveSession: 'Falló al archivar sesión',
+        codexArchiveFailed: 'Codex native archive failed. The session may already be stopped. Retry archiving',
         colorMarker: 'Marcador de color',
         clearColorMarker: 'Quitar marcador de color',
         markerRed: 'Marcador rojo',

--- a/packages/happy-app/sources/text/translations/it.ts
+++ b/packages/happy-app/sources/text/translations/it.ts
@@ -982,6 +982,7 @@ export const it: TranslationStructure = {
         failedToCopyMetadata: 'Impossibile copiare i metadati',
         failedToKillSession: 'Impossibile terminare la sessione',
         failedToArchiveSession: 'Impossibile archiviare la sessione',
+        codexArchiveFailed: 'Codex native archive failed. The session may already be stopped. Retry archiving',
         colorMarker: 'Indicatore colore',
         clearColorMarker: 'Rimuovi indicatore colore',
         markerRed: 'Indicatore rosso',

--- a/packages/happy-app/sources/text/translations/ja.ts
+++ b/packages/happy-app/sources/text/translations/ja.ts
@@ -984,6 +984,7 @@ export const ja: TranslationStructure = {
         failedToCopyMetadata: 'メタデータのコピーに失敗しました',
         failedToKillSession: 'セッションの終了に失敗しました',
         failedToArchiveSession: 'セッションのアーカイブに失敗しました',
+        codexArchiveFailed: 'Codex native archive failed. The session may already be stopped. Retry archiving',
         colorMarker: 'カラーマーカー',
         clearColorMarker: 'カラーマーカーを解除',
         markerRed: '赤のマーカー',

--- a/packages/happy-app/sources/text/translations/pl.ts
+++ b/packages/happy-app/sources/text/translations/pl.ts
@@ -964,6 +964,7 @@ export const pl: TranslationStructure = {
         failedToCopyMetadata: 'Nie udało się skopiować metadanych',
         failedToKillSession: 'Nie udało się zakończyć sesji',
         failedToArchiveSession: 'Nie udało się zarchiwizować sesji',
+        codexArchiveFailed: 'Codex native archive failed. The session may already be stopped. Retry archiving',
         colorMarker: 'Znacznik koloru',
         clearColorMarker: 'Usuń znacznik koloru',
         markerRed: 'Czerwony znacznik',

--- a/packages/happy-app/sources/text/translations/pt.ts
+++ b/packages/happy-app/sources/text/translations/pt.ts
@@ -952,6 +952,7 @@ export const pt: TranslationStructure = {
         failedToCopyMetadata: 'Falha ao copiar metadados',
         failedToKillSession: 'Falha ao encerrar sessão',
         failedToArchiveSession: 'Falha ao arquivar sessão',
+        codexArchiveFailed: 'Codex native archive failed. The session may already be stopped. Retry archiving',
         colorMarker: 'Marcador de cor',
         clearColorMarker: 'Remover marcador de cor',
         markerRed: 'Marcador vermelho',

--- a/packages/happy-app/sources/text/translations/ru.ts
+++ b/packages/happy-app/sources/text/translations/ru.ts
@@ -803,6 +803,7 @@ export const ru: TranslationStructure = {
         failedToCopyMetadata: 'Не удалось скопировать метаданные',
         failedToKillSession: 'Не удалось завершить сессию',
         failedToArchiveSession: 'Не удалось архивировать сессию',
+        codexArchiveFailed: 'Codex native archive failed. The session may already be stopped. Retry archiving',
         colorMarker: 'Цветовая метка',
         clearColorMarker: 'Удалить цветовую метку',
         markerRed: 'Красная метка',

--- a/packages/happy-app/sources/text/translations/zh-Hans.ts
+++ b/packages/happy-app/sources/text/translations/zh-Hans.ts
@@ -954,6 +954,7 @@ export const zhHans: TranslationStructure = {
         failedToCopyMetadata: '复制元数据失败',
         failedToKillSession: '终止会话失败',
         failedToArchiveSession: '归档会话失败',
+        codexArchiveFailed: 'Codex 原生归档失败，会话可能已停止。请重试归档',
         colorMarker: '颜色标记',
         clearColorMarker: '清除颜色标记',
         markerRed: '红色标记',

--- a/packages/happy-app/sources/text/translations/zh-Hant.ts
+++ b/packages/happy-app/sources/text/translations/zh-Hant.ts
@@ -954,6 +954,7 @@ export const zhHant: TranslationStructure = {
         failedToCopyMetadata: '複製中繼資料失敗',
         failedToKillSession: '終止工作階段失敗',
         failedToArchiveSession: '封存工作階段失敗',
+        codexArchiveFailed: 'Codex 原生封存失敗，工作階段可能已停止。請重試封存',
         colorMarker: '顏色標記',
         clearColorMarker: '清除顏色標記',
         markerRed: '紅色標記',

--- a/packages/happy-app/sources/utils/sessionLifecycle.test.ts
+++ b/packages/happy-app/sources/utils/sessionLifecycle.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+import { MetadataSchema, type Session } from '@/sync/storageTypes';
+import { canArchiveSession, canEditSession, canForkSession } from './sessionLifecycle';
+
+function session(flavor: string, lifecycleState?: string): Session {
+    return {
+        active: true,
+        metadata: MetadataSchema.parse({ path: '/project', host: 'host', machineId: 'm1', flavor, lifecycleState }),
+    } as Session;
+}
+
+describe('session lifecycle permissions', () => {
+    it.each(['claude', 'codex', 'gemini'])('allows offline %s forks but rejects explicit archives', flavor => {
+        for (const active of [true, false]) {
+            for (const state of [undefined, 'running']) {
+                expect(canForkSession({ ...session(flavor, state), active })).toBe(true);
+            }
+            expect(canForkSession({ ...session(flavor, 'archived'), active })).toBe(false);
+        }
+    });
+
+    it('checks the latest lifecycle at confirmation and rejects a removed session', () => {
+        const current = session('codex');
+        expect(canForkSession(current)).toBe(true);
+        current.metadata!.lifecycleState = 'archived';
+        expect(canForkSession(current)).toBe(false);
+        expect(canForkSession(undefined)).toBe(false);
+    });
+    it.each(['claude', 'codex', 'gemini'])('keeps offline %s input and queue management available', flavor => {
+        const current = session(flavor, 'running');
+        expect(canEditSession(current)).toBe(true);
+        current.active = false;
+        expect(canEditSession(current)).toBe(true);
+        current.metadata = MetadataSchema.parse({ ...current.metadata, lifecycleState: 'archived' });
+        expect(canEditSession(current)).toBe(false);
+        current.metadata = MetadataSchema.parse({ ...current.metadata, lifecycleState: 'running' });
+        expect(canEditSession(current)).toBe(true);
+        current.active = true;
+        expect(canEditSession(current)).toBe(true);
+    });
+
+    it('preserves lifecycle fields when parsing metadata', () => {
+        const lifecycle = { lifecycleState: 'archived', lifecycleStateSince: 123, archivedBy: 'cli', archiveReason: 'User terminated' };
+        expect(MetadataSchema.parse({ path: '/project', host: 'host', ...lifecycle })).toMatchObject(lifecycle);
+    });
+
+    it('does not infer archival for legacy or missing metadata', () => {
+        const current = session('codex');
+        current.active = false;
+        expect(canEditSession(current)).toBe(true);
+        current.metadata = null;
+        expect(canEditSession(current)).toBe(true);
+    });
+
+    it('keeps explicit archives read-only even before the activity update arrives', () => {
+        expect(canEditSession(session('codex', 'archived'))).toBe(false);
+    });
+
+    it.each([true, false])('respects view-only access when active is %s', active => {
+        expect(canEditSession({ ...session('claude', 'running'), active, accessLevel: 'view' })).toBe(false);
+    });
+
+    it('offers native archive retries for stopped Codex sessions', () => {
+        const current = session('codex', 'archived');
+        current.active = false;
+        expect(canArchiveSession(current, false)).toBe(true);
+        expect(canArchiveSession({ ...current, accessLevel: 'admin' }, false)).toBe(false);
+        current.metadata = { ...current.metadata!, machineId: undefined };
+        expect(canArchiveSession(current, false)).toBe(false);
+    });
+
+    it.each(['claude', 'gemini'])('does not add offline archive actions for %s', flavor => {
+        const current = session(flavor);
+        expect(canArchiveSession(current, true)).toBe(true);
+        current.active = false;
+        expect(canArchiveSession(current, false)).toBe(false);
+    });
+});

--- a/packages/happy-app/sources/utils/sessionLifecycle.ts
+++ b/packages/happy-app/sources/utils/sessionLifecycle.ts
@@ -1,0 +1,16 @@
+import type { Session } from '@/sync/storageTypes';
+
+export function canForkSession(session: Session | undefined): boolean {
+    return !!session && session.metadata?.lifecycleState !== 'archived';
+}
+
+export function canEditSession(session: Session): boolean {
+    // Heartbeat expiry also clears active; only an explicit archive is read-only.
+    return session.accessLevel !== 'view' && session.metadata?.lifecycleState !== 'archived';
+}
+
+export function canArchiveSession(session: Session, isConnected: boolean): boolean {
+    if (session.accessLevel) return false;
+    // Native archive can fail after the session process has already stopped.
+    return isConnected || (!session.active && session.metadata?.flavor === 'codex' && !!session.metadata.machineId);
+}

--- a/packages/happy-cli/src/api/apiMachine.ts
+++ b/packages/happy-cli/src/api/apiMachine.ts
@@ -16,6 +16,8 @@ import { readGeminiSessionLog, listGeminiSessions, getGeminiSessionPreview, save
 import { forkGeminiSession, forkAndTruncateGeminiSession } from '@/gemini/utils/sessionFork';
 import { readAllCodexSessionUserMessages, listCodexSessions, getCodexSessionPreview, saveCodexSessionCacheStats } from '@/codex/utils/codexSessionReader';
 import { forkCodexSession, forkAndTruncateCodexSession } from '@/codex/utils/codexSessionFork';
+import { executeSessionArchive } from '@/daemon/executeSessionArchive';
+import { AsyncLock } from '@/utils/lock';
 import { SessionCache, matchFields, type SessionCacheRuntimeStats } from '@/cache/SessionCache';
 import { encodeBase64, decodeBase64, encrypt, decrypt } from './encryption';
 import { backoff } from '@/utils/time';
@@ -181,6 +183,8 @@ export class ApiMachineClient {
         matchFn: (s, q) => matchFields(q, [s.sessionId, s.title]),
         onStatsChanged: createSessionCacheStatsReporter(saveCodexSessionCacheStats, 'codex'),
     });
+
+    private codexArchiveLock = new AsyncLock();
 
     constructor(
         private token: string,
@@ -634,6 +638,22 @@ export class ApiMachineClient {
 
         // --- Codex session handlers ---
 
+        this.rpcHandlerManager.registerHandler('codex-archive-session', async (params: unknown) => {
+            const request = params as { sessionId?: unknown; nativeSessionId?: unknown } | null;
+            if (!request || typeof request.sessionId !== 'string' || !/^[a-zA-Z0-9_-]+$/.test(request.sessionId)) {
+                throw new Error('sessionId is required');
+            }
+            if (request.nativeSessionId !== undefined && typeof request.nativeSessionId !== 'string') {
+                throw new Error('nativeSessionId must be a string');
+            }
+            const sessionId = request.sessionId;
+            const nativeSessionId = request.nativeSessionId as string | undefined;
+            return this.codexArchiveLock.inLock(async () => {
+                try { return await executeSessionArchive({ sessionId, nativeSessionId }); }
+                finally { this.codexCache.invalidate(); }
+            });
+        });
+
         // Get user messages from a Codex session JSONL
         this.rpcHandlerManager.registerHandler('codex-session-user-messages', async (params: any) => {
             const { codexSessionId, limit = 100, beforeIndex } = params || {};
@@ -671,7 +691,10 @@ export class ApiMachineClient {
             if (!truncateBeforeUuid || typeof truncateBeforeUuid !== 'string') {
                 throw new Error('truncateBeforeUuid is required');
             }
-            return await forkAndTruncateCodexSession(codexSessionId, truncateBeforeUuid);
+            return this.codexArchiveLock.inLock(async () => {
+                try { return await forkAndTruncateCodexSession(codexSessionId, truncateBeforeUuid); }
+                finally { this.codexCache.invalidate(); }
+            });
         });
 
         // Fork a Codex session without truncation (resume)
@@ -680,7 +703,10 @@ export class ApiMachineClient {
             if (!codexSessionId || typeof codexSessionId !== 'string') {
                 throw new Error('codexSessionId is required');
             }
-            return await forkCodexSession(codexSessionId);
+            return this.codexArchiveLock.inLock(async () => {
+                try { return await forkCodexSession(codexSessionId, params.restoreArchived === true); }
+                finally { this.codexCache.invalidate(); }
+            });
         });
 
         // --- Gemini session listing & preview ---

--- a/packages/happy-cli/src/api/apiSession.ts
+++ b/packages/happy-cli/src/api/apiSession.ts
@@ -1,3 +1,4 @@
+import { recordSessionBinding } from '@/daemon/sessionBinding';
 import { logger } from '@/ui/logger'
 import { EventEmitter } from 'node:events'
 import { io, Socket } from 'socket.io-client'
@@ -147,6 +148,7 @@ export class ApiSessionClient extends EventEmitter {
         this.token = token;
         this.sessionId = session.id;
         this.metadata = session.metadata;
+        recordSessionBinding(session.id, session.metadata);
         this.metadataVersion = session.metadataVersion;
         this.agentState = session.agentState;
         this.agentStateVersion = session.agentStateVersion;
@@ -1081,6 +1083,7 @@ export class ApiSessionClient extends EventEmitter {
         this.metadataLock.inLock(async () => {
             await backoff(async () => {
                 let updated = stripCapabilitiesFromMetadata(handler(this.metadata!)); // Weird state if metadata is null - should never happen but here we are
+                recordSessionBinding(this.sessionId, updated);
                 const answer = await this.socket.emitWithAck('update-metadata', { sid: this.sessionId, expectedVersion: this.metadataVersion, metadata: encodeBase64(encrypt(this.encryptionKey, this.encryptionVariant, updated)) });
                 if (answer.result === 'success') {
                     this.metadata = decrypt(this.encryptionKey, this.encryptionVariant, decodeBase64(answer.metadata));

--- a/packages/happy-cli/src/api/types.ts
+++ b/packages/happy-cli/src/api/types.ts
@@ -370,6 +370,7 @@ export type Metadata = {
   summaryPinned?: boolean,
   machineId?: string,
   claudeSessionId?: string, // Claude Code session ID
+  codexSessionId?: string,
   tools?: string[],
   slashCommands?: string[],
   slashCommandMetadata?: Array<{

--- a/packages/happy-cli/src/codex/appserver/CodexAppServerBackend.test.ts
+++ b/packages/happy-cli/src/codex/appserver/CodexAppServerBackend.test.ts
@@ -2,6 +2,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { CodexAppServerBackend, resolveModel } from './CodexAppServerBackend';
 import { Methods } from './types';
 import { logger } from '@/ui/logger';
+import { recordNativeThreadEmpty } from '@/daemon/sessionBinding';
+
+vi.mock('@/daemon/sessionBinding', () => ({ recordNativeThreadEmpty: vi.fn(), recordManagedProcess: vi.fn() }));
 
 function createBackend(): CodexAppServerBackend {
   return new CodexAppServerBackend({
@@ -64,6 +67,7 @@ describe('CodexAppServerBackend.startSession resume routing', () => {
       })
     );
     expect(request).not.toHaveBeenCalledWith(Methods.THREAD_START, expect.anything());
+    expect(recordNativeThreadEmpty).toHaveBeenCalledWith('thread-resumed', false);
   });
 
   it('uses thread/start when neither resumeThreadId nor resumeFile is provided', async () => {
@@ -97,6 +101,39 @@ describe('CodexAppServerBackend.startSession resume routing', () => {
 
     expect(request).toHaveBeenCalledWith(Methods.THREAD_START, expect.anything());
     expect(request).not.toHaveBeenCalledWith(Methods.THREAD_RESUME, expect.anything());
+    expect(recordNativeThreadEmpty).toHaveBeenCalledWith('thread-new', true);
+  });
+
+  it('clears empty-thread evidence before a turn RPC even if the request fails', async () => {
+    const backend = createBackend();
+    const anyBackend = backend as any;
+    anyBackend.threadId = 'empty';
+    const request = vi.fn().mockRejectedValue(new Error('disconnected'));
+    anyBackend.peer = { request };
+    await expect(anyBackend.doSendMessage('hello')).rejects.toThrow('disconnected');
+    expect(recordNativeThreadEmpty).toHaveBeenCalledWith('empty', false);
+    expect(vi.mocked(recordNativeThreadEmpty).mock.invocationCallOrder.at(-1)).toBeLessThan(request.mock.invocationCallOrder[0]);
+  });
+
+  it('does not submit a turn if clearing durable empty-thread evidence fails', async () => {
+    const backend = createBackend();
+    const anyBackend = backend as any;
+    anyBackend.threadId = 'empty';
+    const request = vi.fn();
+    anyBackend.peer = { request };
+    vi.mocked(recordNativeThreadEmpty).mockImplementationOnce(() => { throw new Error('disk full'); });
+    await expect(anyBackend.doSendMessage('hello')).rejects.toThrow('disk full');
+    expect(request).not.toHaveBeenCalled();
+  });
+
+  it.each(['compactThread', 'startReview', 'setGoal', 'clearGoal'])('clears empty-thread evidence before %s can persist history', async method => {
+    const backend = createBackend() as any;
+    backend.threadId = 'empty';
+    const request = vi.fn().mockResolvedValue({});
+    backend.peer = { request };
+    await backend[method]({ type: 'uncommittedChanges' });
+    expect(recordNativeThreadEmpty).toHaveBeenCalledWith('empty', false);
+    expect(vi.mocked(recordNativeThreadEmpty).mock.invocationCallOrder.at(-1)).toBeLessThan(request.mock.invocationCallOrder[0]);
   });
 
   it('detects the structured legacy denial format from Codex 0.145.0', async () => {

--- a/packages/happy-cli/src/codex/appserver/CodexAppServerBackend.ts
+++ b/packages/happy-cli/src/codex/appserver/CodexAppServerBackend.ts
@@ -10,6 +10,7 @@
  */
 
 import { CodexJsonRpcPeer } from './CodexJsonRpcPeer';
+import { recordNativeThreadEmpty } from '@/daemon/sessionBinding';
 import {
   Methods,
   type InitializeParams,
@@ -253,6 +254,7 @@ export class CodexAppServerBackend implements AgentBackend {
         resumeParams
       );
       threadId = resumeResult.thread.id;
+      recordNativeThreadEmpty(threadId, false);
       this.handleSessionConfigured({
         sessionId: threadId,
         model: resumeResult.model,
@@ -264,6 +266,7 @@ export class CodexAppServerBackend implements AgentBackend {
         this.buildThreadParams()
       );
       threadId = newResult.thread.id;
+      recordNativeThreadEmpty(threadId, true);
       logger.info(`[CodexBackend] New thread: id=${threadId}, model=${newResult.model}`);
       this.handleSessionConfigured({
         sessionId: threadId,
@@ -332,6 +335,7 @@ export class CodexAppServerBackend implements AgentBackend {
     if (!this.threadId) {
       throw new Error('CodexAppServerBackend: no active thread');
     }
+    recordNativeThreadEmpty(this.threadId, false);
     await this.peer.request(Methods.THREAD_COMPACT_START, {
       threadId: this.threadId,
     } satisfies ThreadCompactStartParams);
@@ -342,6 +346,7 @@ export class CodexAppServerBackend implements AgentBackend {
       throw new Error('CodexAppServerBackend: no active thread');
     }
     this.resetTurnComplete();
+    recordNativeThreadEmpty(this.threadId, false);
     await this.peer.request(Methods.REVIEW_START, {
       threadId: this.threadId,
       target,
@@ -362,6 +367,7 @@ export class CodexAppServerBackend implements AgentBackend {
     if (!this.threadId) {
       throw new Error('CodexAppServerBackend: no active thread');
     }
+    recordNativeThreadEmpty(this.threadId, false);
     await this.peer.request(Methods.THREAD_GOAL_SET, {
       threadId: this.threadId,
       ...params,
@@ -372,6 +378,7 @@ export class CodexAppServerBackend implements AgentBackend {
     if (!this.threadId) {
       throw new Error('CodexAppServerBackend: no active thread');
     }
+    recordNativeThreadEmpty(this.threadId, false);
     await this.peer.request(Methods.THREAD_GOAL_CLEAR, {
       threadId: this.threadId,
     } satisfies ThreadGoalClearParams);
@@ -523,6 +530,7 @@ export class CodexAppServerBackend implements AgentBackend {
       text: prompt,
     });
 
+    recordNativeThreadEmpty(this.threadId, false);
     const result = await this.peer.request<TurnStartResponse>(Methods.TURN_START, {
       threadId: this.threadId,
       input,

--- a/packages/happy-cli/src/codex/appserver/CodexJsonRpcPeer.ts
+++ b/packages/happy-cli/src/codex/appserver/CodexJsonRpcPeer.ts
@@ -14,6 +14,7 @@
 import { spawn, execSync, type ChildProcess } from 'node:child_process';
 import { createInterface, type Interface as ReadlineInterface } from 'node:readline';
 import { logger } from '@/ui/logger';
+import { recordManagedProcess } from '@/daemon/sessionBinding';
 
 export interface SpawnOptions {
   cwd: string;
@@ -72,6 +73,7 @@ export class CodexJsonRpcPeer {
       detached: true,  // Create new process group so we can kill all children
     });
 
+    recordManagedProcess(this.process.pid);
     this.exitPromise = new Promise<number | null>((resolve) => {
       this.process!.on('close', (code) => {
         this.exited = true;

--- a/packages/happy-cli/src/codex/runCodex.ts
+++ b/packages/happy-cli/src/codex/runCodex.ts
@@ -610,6 +610,7 @@ export async function runCodex(opts: {
     // Register abort handler
     session.rpcHandlerManager.registerHandler('abort', () => handleAbort({ graceful: true }));
     registerKillSessionHandler(session.rpcHandlerManager, handleKillSession);
+    process.on('SIGTERM', handleKillSession);
 
     //
     // Initialize Ink UI

--- a/packages/happy-cli/src/codex/utils/codexSessionFork.test.ts
+++ b/packages/happy-cli/src/codex/utils/codexSessionFork.test.ts
@@ -8,6 +8,8 @@ import { Methods } from '../appserver/types';
 import { CODEX_PACKAGE } from '../package';
 
 const peer = vi.hoisted(() => ({ spawn: vi.fn(), request: vi.fn(), notify: vi.fn(), close: vi.fn() }));
+const restore = vi.hoisted(() => vi.fn());
+vi.mock('@/daemon/executeSessionArchive', () => ({ restoreCodexSession: restore }));
 vi.mock('../appserver/CodexJsonRpcPeer', () => ({ CodexJsonRpcPeer: vi.fn(() => peer) }));
 
 const sourceId = '11111111-2222-4333-8444-555555555555';
@@ -70,6 +72,52 @@ describe('Codex session fork', () => {
     expect(await readFile(sourcePath, 'utf-8')).toBe(sourceContent);
     expect(await readdir(join(home, 'sessions'))).toHaveLength(2);
     expect(peer.close).toHaveBeenCalledOnce();
+    expect(restore).not.toHaveBeenCalled();
+  });
+
+  it('restores archived history before native fork using the original Codex home', async () => {
+    const originalHome = join(home, 'original-home');
+    await mkdir(join(originalHome, 'sessions'), { recursive: true });
+    const restoredPath = join(originalHome, 'sessions', sourcePath.split('/').pop()!);
+    await rm(sourcePath);
+    restore.mockImplementation(async () => {
+      await writeFile(restoredPath, sourceContent);
+      return originalHome;
+    });
+    expect(await forkCodexSession(sourceId, true)).toEqual({ success: true, newFilePath: forkPath });
+    expect(restore).toHaveBeenCalledWith(sourceId);
+    expect(peer.spawn).toHaveBeenCalledWith('npx', ['-y', CODEX_PACKAGE, 'app-server'], {
+      cwd: process.cwd(), env: { CODEX_HOME: originalHome },
+    });
+    expect(restore.mock.invocationCallOrder[0]).toBeLessThan(peer.spawn.mock.invocationCallOrder[0]);
+    expect(peer.request).toHaveBeenCalledWith(Methods.THREAD_FORK, { threadId: sourceId, excludeTurns: true });
+  });
+
+  it('does not fork when native restore fails', async () => {
+    await rm(sourcePath);
+    restore.mockRejectedValue(new Error('native failure'));
+    expect(await forkCodexSession(sourceId, true)).toMatchObject({
+      success: false, errorMessage: expect.stringContaining('Could not restore'),
+    });
+    expect(peer.spawn).not.toHaveBeenCalled();
+  });
+
+  it('does not fork when restored history is still missing', async () => {
+    await rm(sourcePath);
+    restore.mockResolvedValue(home);
+    expect((await forkCodexSession(sourceId, true)).success).toBe(false);
+    expect(restore).toHaveBeenCalledWith(sourceId);
+    expect(peer.spawn).not.toHaveBeenCalled();
+  });
+
+  it('does not restore missing history for ordinary or message-level forks', async () => {
+    await rm(sourcePath);
+    expect(await forkCodexSession(sourceId)).toMatchObject({
+      success: false, errorMessage: expect.stringContaining('Restore the session'),
+    });
+    expect((await forkAndTruncateCodexSession(sourceId, 'message-1', true)).success).toBe(false);
+    expect(restore).not.toHaveBeenCalled();
+    expect(peer.spawn).not.toHaveBeenCalled();
   });
 
   it('resolves display suffixes to the full native thread ID', async () => {

--- a/packages/happy-cli/src/codex/utils/codexSessionFork.ts
+++ b/packages/happy-cli/src/codex/utils/codexSessionFork.ts
@@ -3,6 +3,7 @@
 import { stat } from 'node:fs/promises';
 import { basename, isAbsolute } from 'node:path';
 import { z } from 'zod';
+import { restoreCodexSession } from '@/daemon/executeSessionArchive';
 import { logger } from '@/ui/logger';
 import { CODEX_PACKAGE } from '@/codex/package';
 import { CodexJsonRpcPeer } from '../appserver/CodexJsonRpcPeer';
@@ -92,18 +93,32 @@ async function findPreviousTurn(peer: CodexJsonRpcPeer, threadId: string, target
   throw new Error('Selected Codex turn is no longer present in the session');
 }
 
-export async function forkCodexSession(codexSessionId: string): Promise<CodexForkResult> {
-  return forkAndTruncateCodexSession(codexSessionId);
+export async function forkCodexSession(codexSessionId: string, restoreArchived = false): Promise<CodexForkResult> {
+  return forkAndTruncateCodexSession(codexSessionId, undefined, restoreArchived);
 }
 
 /** Preserve history before the selected user message, never mutating the source thread. */
 export async function forkAndTruncateCodexSession(
   codexSessionId: string,
   truncateBeforeUuid?: string,
+  restoreArchived = false,
 ): Promise<CodexForkResult> {
   let peer: CodexJsonRpcPeer | undefined;
   try {
-    const originalPath = findCodexSessionFile(codexSessionId);
+    let originalPath = findCodexSessionFile(codexSessionId);
+    let codexHome: string | undefined;
+    if (!originalPath) {
+      if (!restoreArchived || truncateBeforeUuid) {
+        throw new Error('Session history is unavailable. Restore the session before forking.');
+      }
+      try {
+        codexHome = await restoreCodexSession(codexSessionId);
+        originalPath = findCodexSessionFile(codexSessionId, codexHome);
+      } catch (error) {
+        logger.debug('[CodexSessionFork] Native restore failed', error);
+        throw new Error('Could not restore the native Codex session. Check that its original machine and Codex installation are available.');
+      }
+    }
     if (!originalPath) throw new Error(`Codex session file not found for: ${codexSessionId}`);
     const { threadId, targetTurnId } = readForkSource(await readCodexSessionContent(originalPath), truncateBeforeUuid);
     // Old Happy copies kept the source ID inside a renamed rollout. Do not silently fork the original instead.
@@ -112,7 +127,10 @@ export async function forkAndTruncateCodexSession(
     }
 
     peer = new CodexJsonRpcPeer();
-    await peer.spawn('npx', ['-y', CODEX_PACKAGE, 'app-server'], { cwd: process.cwd() });
+    await peer.spawn('npx', ['-y', CODEX_PACKAGE, 'app-server'], {
+      cwd: process.cwd(),
+      ...(codexHome ? { env: { CODEX_HOME: codexHome } } : {}),
+    });
     await peer.request(Methods.INITIALIZE, {
       clientInfo: { name: 'happy-codex-fork', version: '1.0.0' },
       capabilities: { experimentalApi: true },

--- a/packages/happy-cli/src/codex/utils/codexSessionReader.ts
+++ b/packages/happy-cli/src/codex/utils/codexSessionReader.ts
@@ -39,10 +39,9 @@ export interface CodexUserMessage {
  * Find Codex's native JSONL session file by conversationId.
  * Searches $CODEX_HOME/sessions/ recursively for files ending with -{codexSessionId}.jsonl
  */
-export function findCodexSessionFile(codexSessionId: string): string | null {
+export function findCodexSessionFile(codexSessionId: string, codexHomeDir = getCodexHomeDir()): string | null {
   if (!codexSessionId) return null;
   try {
-    const codexHomeDir = getCodexHomeDir();
     const rootDir = join(codexHomeDir, 'sessions');
 
     const query = codexSessionId.trim();

--- a/packages/happy-cli/src/daemon/executeSessionArchive.integration.test.ts
+++ b/packages/happy-cli/src/daemon/executeSessionArchive.integration.test.ts
@@ -1,0 +1,47 @@
+import { mkdirSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { expect, it } from 'vitest';
+import { CodexJsonRpcPeer } from '@/codex/appserver/CodexJsonRpcPeer';
+import { CodexAppServerBackend } from '@/codex/appserver/CodexAppServerBackend';
+import { configuration } from '@/configuration';
+import type { Metadata } from '@/api/types';
+import { recordSessionBinding, readSessionBinding } from './sessionBinding';
+import { syncCodexArchive } from './executeSessionArchive';
+
+it('archives a goal-only thread after its original app-server exits', async () => {
+    const directory = mkdtempSync(join(tmpdir(), 'happy-empty-native-'));
+    const sessionId = `empty-native-${Date.now()}`;
+    const codexHome = join(directory, 'codex');
+    mkdirSync(codexHome);
+    const previousHome = process.env.CODEX_HOME;
+    process.env.CODEX_HOME = codexHome;
+    const backend = new CodexAppServerBackend({ cwd: directory, command: 'npx', args: ['-y', '@openai/codex@0.145.0', 'app-server'] });
+    const peer = new CodexJsonRpcPeer();
+    try {
+        recordSessionBinding(sessionId, { path: directory, flavor: 'codex' } as Metadata);
+        const { sessionId: threadId } = await backend.startSession();
+        await backend.getGoal();
+        await backend.dispose();
+        const binding = readSessionBinding(sessionId)!;
+        expect(binding.emptyNativeSessionIds).toContain(threadId);
+
+        await peer.spawn('npx', ['-y', '@openai/codex@0.145.0', 'app-server'], { cwd: directory, env: { CODEX_HOME: codexHome } });
+        await peer.request('initialize', { clientInfo: { name: 'happy-test', version: '1.0.0' } });
+        peer.notify('initialized', {});
+        await expect(peer.request('thread/archive', { threadId })).rejects.toThrow(/no rollout found/i);
+        await peer.close();
+
+        await expect(syncCodexArchive(binding, true)).resolves.toBeUndefined();
+        await expect(syncCodexArchive(binding, true)).resolves.toBeUndefined();
+    } finally {
+        await backend.dispose();
+        await peer.close();
+        if (previousHome === undefined) delete process.env.CODEX_HOME;
+        else process.env.CODEX_HOME = previousHome;
+        for (const suffix of ['.json', '.json.stop']) {
+            rmSync(join(configuration.happyHomeDir, 'session-bindings', `${sessionId}${suffix}`), { force: true });
+        }
+        rmSync(directory, { recursive: true, force: true });
+    }
+}, 120_000);

--- a/packages/happy-cli/src/daemon/executeSessionArchive.test.ts
+++ b/packages/happy-cli/src/daemon/executeSessionArchive.test.ts
@@ -1,0 +1,197 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const { binding, rpc, running } = vi.hoisted(() => ({
+    binding: { sessionId: 'happy-1', provider: 'codex', cwd: '/tmp', pid: 999999,
+        identity: 'start S', nativeSessionIds: ['native-1'], processes: [] },
+    rpc: { spawn: vi.fn(), request: vi.fn(), notify: vi.fn(), close: vi.fn(), pid: undefined as number | undefined },
+    running: vi.fn(),
+}));
+const home = vi.hoisted(() => ({ value: '' }));
+vi.mock('@/configuration', () => ({ configuration: { get happyHomeDir() { return home.value; } } }));
+vi.mock('./sessionBinding', () => ({
+    readSessionBinding: vi.fn(() => binding), listSessionBindings: vi.fn(() => [binding]),
+    isBindingRunning: running, processIdentity: vi.fn(),
+    readStopSnapshot: vi.fn(() => []), writeStopSnapshot: vi.fn(),
+}));
+vi.mock('@/codex/appserver/CodexJsonRpcPeer', () => ({ CodexJsonRpcPeer: vi.fn(() => rpc) }));
+import { executeSessionArchive, syncCodexArchive, restoreCodexSession } from './executeSessionArchive';
+import { readSessionBinding, listSessionBindings, processIdentity, writeStopSnapshot, type SessionBinding } from './sessionBinding';
+
+describe('executeSessionArchive', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        binding.provider = 'codex';
+        binding.nativeSessionIds = ['native-1'];
+        rpc.pid = undefined;
+        running.mockReturnValue(false);
+        vi.mocked(readSessionBinding).mockReturnValue(binding as SessionBinding);
+        vi.mocked(listSessionBindings).mockReturnValue([binding as SessionBinding]);
+        rpc.request.mockResolvedValue({ data: [], nextCursor: null });
+    });
+    afterEach(() => { if (home.value) rmSync(home.value, { recursive: true, force: true }); });
+    it('restores native history after worktree cleanup using a stable cwd and the original Codex home', async () => {
+        home.value = mkdtempSync(join(tmpdir(), 'happy-archive-cwd-'));
+        const removedCwd = join(home.value, 'deleted-worktree');
+        await syncCodexArchive({ ...binding, provider: 'codex', cwd: removedCwd, codexHome: '../codex-data' } as SessionBinding, false);
+        expect(rpc.spawn).toHaveBeenCalledWith('npx', expect.any(Array), expect.objectContaining({
+            cwd: join(home.value, 'archive-runtime'), env: { CODEX_HOME: join(home.value, 'codex-data') },
+        }));
+        expect(rpc.request).toHaveBeenCalledWith('thread/unarchive', { threadId: 'native-1' }, 20000);
+    });
+    it('does not repeat native restore when a successful acknowledgement was lost', async () => {
+        rpc.request.mockResolvedValueOnce({}).mockResolvedValueOnce({ data: [{ id: 'native-1' }] });
+        await syncCodexArchive(binding as SessionBinding, false);
+        expect(rpc.request.mock.calls.some(([method]) => method === 'thread/unarchive')).toBe(false);
+    });
+    it('records the native helper before sending any native side effects', async () => {
+        rpc.pid = 999998;
+        vi.mocked(processIdentity).mockReturnValue('helper S');
+        await syncCodexArchive(binding as SessionBinding, true);
+        expect(writeStopSnapshot).toHaveBeenCalledWith(binding, [{ pid: 999998, identity: 'helper S' }]);
+        expect(vi.mocked(writeStopSnapshot).mock.invocationCallOrder[0]).toBeLessThan(rpc.request.mock.invocationCallOrder[0]);
+    });
+    it('does not report restore success if process verification fails', async () => {
+        running.mockImplementation(() => { throw new Error('process-verification-unsupported'); });
+        expect(await executeSessionArchive({ sessionId: 'happy-1' }))
+            .toMatchObject({ error: 'process-verification-unsupported' });
+        expect(rpc.spawn).not.toHaveBeenCalled();
+    });
+
+    it.each(['claude', 'gemini'] as const)('rejects %s without touching its processes or history', async provider => {
+        binding.provider = provider;
+        expect(await executeSessionArchive({ sessionId: 'happy-1' }))
+            .toEqual({ success: false, stopped: false, error: 'session-provider-mismatch' });
+        expect(rpc.spawn).not.toHaveBeenCalled();
+    });
+    it('does not treat missing process identity as success', async () => {
+        vi.mocked(readSessionBinding).mockReturnValue(null);
+        expect(await executeSessionArchive({ sessionId: 'happy-1' }))
+            .toMatchObject({ success: false, stopped: false, error: 'session-identity-unavailable' });
+        expect(running).not.toHaveBeenCalled();
+        expect(writeStopSnapshot).not.toHaveBeenCalled();
+        expect(rpc.spawn).not.toHaveBeenCalled();
+    });
+    it('completes an empty Codex session without a native helper', async () => {
+        binding.provider = 'codex';
+        binding.nativeSessionIds = [];
+        expect(await executeSessionArchive({ sessionId: 'happy-1' }))
+            .toEqual({ success: true, stopped: true });
+        expect(running).toHaveBeenCalled();
+        expect(rpc.spawn).not.toHaveBeenCalled();
+        expect(rpc.request).not.toHaveBeenCalled();
+    });
+    it('does not treat a known native thread with missing identity as an empty session', async () => {
+        binding.provider = 'codex';
+        binding.nativeSessionIds = [];
+        expect(await executeSessionArchive({ sessionId: 'happy-1', nativeSessionId: 'native-1' }))
+            .toMatchObject({ error: 'native-session-id-unavailable', stopped: false });
+        expect(running).not.toHaveBeenCalled();
+        expect(rpc.spawn).not.toHaveBeenCalled();
+    });
+    it('syncs a native thread recorded during shutdown of an initially empty session', async () => {
+        binding.provider = 'codex';
+        vi.mocked(readSessionBinding).mockReturnValueOnce({ ...binding, nativeSessionIds: [] } as SessionBinding);
+        expect(await executeSessionArchive({ sessionId: 'happy-1' }))
+            .toEqual({ success: true, stopped: true });
+        expect(rpc.request).toHaveBeenCalledWith('thread/archive', { threadId: 'native-1' }, 20000);
+    });
+    it('does not treat IDs lost during shutdown as an empty session', async () => {
+        binding.provider = 'codex';
+        vi.mocked(readSessionBinding).mockReturnValueOnce(binding as SessionBinding)
+            .mockReturnValueOnce({ ...binding, nativeSessionIds: [] } as SessionBinding);
+        const result = await executeSessionArchive({ sessionId: 'happy-1' });
+        expect(result).toMatchObject({ stopped: true, error: 'native-session-id-unavailable' });
+        expect(result.success).toBe(false);
+        expect(rpc.spawn).not.toHaveBeenCalled();
+    });
+    it('refuses a native session used by another live Happy session', async () => {
+        vi.mocked(listSessionBindings).mockReturnValue([binding as SessionBinding, { ...binding, sessionId: 'happy-2' } as SessionBinding]);
+        running.mockImplementation(process => process.sessionId === 'happy-2');
+        expect(await executeSessionArchive({ sessionId: 'happy-1' }))
+            .toEqual({ success: false, stopped: true, error: 'native-session-in-use' });
+        expect(running.mock.calls[0][0]).toBe(binding);
+        expect(rpc.spawn).not.toHaveBeenCalled();
+        expect(rpc.request).not.toHaveBeenCalled();
+    });
+    it('does not archive a session restarted while its old wrapper was stopping', async () => {
+        const restarted = { ...binding, pid: 999998 } as SessionBinding;
+        vi.mocked(readSessionBinding).mockReturnValueOnce(binding as SessionBinding).mockReturnValueOnce(restarted);
+        running.mockImplementation(process => process.pid === restarted.pid);
+        expect(await executeSessionArchive({ sessionId: 'happy-1' }))
+            .toMatchObject({ success: false, stopped: false, error: 'native-session-in-use' });
+        expect(rpc.spawn).not.toHaveBeenCalled();
+    });
+    it('archives Codex without starting or resuming a thread', async () => {
+        binding.provider = 'codex';
+        expect(await executeSessionArchive({ sessionId: 'happy-1' }))
+            .toEqual({ success: true, stopped: true });
+        expect(rpc.request).toHaveBeenCalledWith('thread/archive', { threadId: 'native-1' }, 20000);
+        expect(rpc.request.mock.calls.some(([method]) => ['thread/start', 'thread/resume'].includes(method))).toBe(false);
+        expect(rpc.close).toHaveBeenCalled();
+    });
+    it('retains stop success when native archive fails', async () => {
+        binding.provider = 'codex';
+        rpc.request.mockRejectedValue(new Error('native error with private path'));
+        expect(await executeSessionArchive({ sessionId: 'happy-1' }))
+            .toEqual({ success: false, stopped: true, error: 'native-archive-failed' });
+        expect(rpc.close).toHaveBeenCalled();
+    });
+    it('skips a proven empty thread and archives later threads, including on retries', async () => {
+        const empty = { ...binding, nativeSessionIds: ['empty', 'native-1'], emptyNativeSessionIds: ['empty'] } as SessionBinding;
+        vi.mocked(readSessionBinding).mockReturnValue(empty);
+        vi.mocked(listSessionBindings).mockReturnValue([empty]);
+        rpc.request.mockImplementation(async (method, params) => {
+            if (method === 'thread/archive' && params.threadId === 'empty') throw new Error('no rollout found for thread id empty');
+            return { data: [], nextCursor: null };
+        });
+        for (let i = 0; i < 2; i++) {
+            expect(await executeSessionArchive({ sessionId: 'happy-1' })).toEqual({ success: true, stopped: true });
+        }
+        expect(rpc.request).toHaveBeenCalledWith('thread/archive', { threadId: 'native-1' }, 20000);
+        expect(rpc.close).toHaveBeenCalledTimes(2);
+    });
+
+    it.each(['unknown', 'previously-used', 'restore', 'permission'])('does not suppress %s history failures', async scenario => {
+        const empty = { ...binding, emptyNativeSessionIds: scenario === 'unknown' ? undefined : ['native-1'] } as SessionBinding;
+        vi.mocked(listSessionBindings).mockReturnValue(scenario === 'previously-used' ? [empty, { ...binding, sessionId: 'other' } as SessionBinding] : [empty]);
+        const message = scenario === 'permission' ? 'permission denied' : 'no rollout found for thread id native-1';
+        rpc.request.mockImplementation(async method => {
+            if (method === 'thread/archive' || method === 'thread/unarchive') throw new Error(message);
+            return { data: [], nextCursor: null };
+        });
+        await expect(syncCodexArchive(empty, scenario !== 'restore')).rejects.toThrow(message);
+        expect(rpc.close).toHaveBeenCalled();
+    });
+    it('skips already archived threads on later list pages', async () => {
+        rpc.request.mockResolvedValueOnce({}).mockResolvedValueOnce({ data: [], nextCursor: 'next' })
+            .mockResolvedValueOnce({ data: [{ id: 'native-1' }], nextCursor: null });
+        await syncCodexArchive(binding as SessionBinding, true);
+        expect(rpc.request.mock.calls.some(([method]) => method === 'thread/archive')).toBe(false);
+    });
+    it('unarchives without starting a new conversation', async () => {
+        await syncCodexArchive(binding as SessionBinding, false);
+        expect(rpc.request).toHaveBeenCalledWith('thread/unarchive', { threadId: 'native-1' }, 20000);
+    });
+
+    it('restores only the requested native thread, without creating a conversation', async () => {
+        binding.nativeSessionIds = ['native-1', 'native-2'];
+        await restoreCodexSession('native-2');
+        expect(rpc.request).toHaveBeenCalledWith('thread/unarchive', { threadId: 'native-2' }, 20000);
+        expect(rpc.request.mock.calls.some(([method, params]) => method === 'thread/unarchive' && params.threadId === 'native-1')).toBe(false);
+        expect(rpc.request.mock.calls.some(([method]) => ['thread/start', 'thread/resume'].includes(method))).toBe(false);
+    });
+
+    it('refuses to restore a thread still in use by a Happy process', async () => {
+        running.mockReturnValue(true);
+        await expect(restoreCodexSession('native-1')).rejects.toThrow('native-session-in-use');
+        expect(rpc.spawn).not.toHaveBeenCalled();
+    });
+
+    it('does not restore an unknown thread using an invented binding', async () => {
+        await expect(restoreCodexSession('unknown')).rejects.toThrow('session-identity-unavailable');
+        expect(rpc.spawn).not.toHaveBeenCalled();
+    });
+});

--- a/packages/happy-cli/src/daemon/executeSessionArchive.ts
+++ b/packages/happy-cli/src/daemon/executeSessionArchive.ts
@@ -1,0 +1,160 @@
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, statSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { homedir } from 'node:os';
+import { configuration } from '@/configuration';
+import { CodexJsonRpcPeer } from '@/codex/appserver/CodexJsonRpcPeer';
+import { CODEX_PACKAGE } from '@/codex/package';
+import { readSessionBinding, listSessionBindings, isBindingRunning, processIdentity, readStopSnapshot, writeStopSnapshot, type SessionBinding } from './sessionBinding';
+
+const delay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+
+export async function stopBoundSession(binding: SessionBinding, signal?: AbortSignal): Promise<void> {
+    signal?.throwIfAborted();
+    const roots = [binding, ...binding.processes, ...readStopSnapshot(binding)].filter(isBindingRunning);
+    if (!roots.length) return;
+    // Snapshot children before stopping the parent: detached backend groups can outlive it.
+    const rows = execFileSync('ps', ['-axo', 'pid=,ppid='], { encoding: 'utf8', timeout: 5000 })
+        .trim().split('\n').map(line => line.trim().split(/\s+/).map(Number));
+    const descendants = new Set(roots.map(root => root.pid));
+    let changed = true;
+    while (changed) {
+        changed = false;
+        for (const [pid, parent] of rows) if (descendants.has(parent) && !descendants.has(pid)) {
+            descendants.add(pid); changed = true;
+        }
+    }
+    const processes = [...descendants].flatMap(pid => {
+        const identity = roots.find(root => root.pid === pid)?.identity ?? processIdentity(pid);
+        return identity ? [{ pid, identity }] : [];
+    });
+    writeStopSnapshot(binding, processes);
+    const sendSignal = (sig: NodeJS.Signals) => {
+        signal?.throwIfAborted();
+        for (const process of processes) if (isBindingRunning(process)) {
+            try { global.process.kill(process.pid, sig); }
+            catch (error) { if ((error as NodeJS.ErrnoException).code !== 'ESRCH') throw error; }
+        }
+    };
+    // Give the Happy wrapper time to flush and shut down its backends gracefully.
+    if (isBindingRunning(binding)) {
+        process.kill(binding.pid, 'SIGTERM');
+        for (let i = 0; i < 40 && processes.some(isBindingRunning); i++) await delay(250);
+    }
+    sendSignal('SIGTERM');
+    for (let i = 0; i < 8 && processes.some(isBindingRunning); i++) await delay(250);
+    sendSignal('SIGKILL');
+    for (let i = 0; i < 8 && processes.some(isBindingRunning); i++) await delay(250);
+    if (processes.some(isBindingRunning)) throw new Error('stop-not-confirmed');
+}
+
+export async function syncCodexArchive(binding: SessionBinding, archived: boolean, signal?: AbortSignal): Promise<void> {
+    signal?.throwIfAborted();
+    if (!binding.nativeSessionIds.length) return;
+    const peer = new CodexJsonRpcPeer();
+    const controller = new AbortController();
+    const abort = () => controller.abort();
+    signal?.addEventListener('abort', abort, { once: true });
+    const timeout = setTimeout(() => controller.abort(), 75_000);
+    try {
+        let cwd = binding.cwd;
+        try {
+            if (!statSync(cwd).isDirectory()) throw Object.assign(new Error('Not a directory'), { code: 'ENOTDIR' });
+        } catch (error) {
+            if (!['ENOENT', 'ENOTDIR'].includes((error as NodeJS.ErrnoException).code ?? '')) throw error;
+            cwd = join(configuration.happyHomeDir, 'archive-runtime');
+            mkdirSync(cwd, { recursive: true, mode: 0o700 });
+        }
+        await peer.spawn('npx', ['-y', binding.codexPackage ?? CODEX_PACKAGE, 'app-server'], {
+            cwd,
+            signal: controller.signal,
+            env: { CODEX_HOME: binding.codexHome ? resolve(binding.cwd, binding.codexHome) : join(homedir(), '.codex') },
+        });
+        // Persist the native helper before issuing side effects, so a replacement daemon
+        // can stop an orphaned helper before reconciling the same threads.
+        if (peer.pid) {
+            const identity = processIdentity(peer.pid);
+            if (!identity) throw new Error('process-verification-unsupported');
+            writeStopSnapshot(binding, [...readStopSnapshot(binding), { pid: peer.pid, identity }]);
+        }
+        await peer.request('initialize', { clientInfo: { name: 'happy-archive', version: '1.0.0' } }, 15_000);
+        peer.notify('initialized', {});
+        // No resume/start: archive existing persisted threads without creating a new conversation.
+        for (const threadId of binding.nativeSessionIds) {
+            signal?.throwIfAborted();
+            // Check the target state so retries after a lost acknowledgement are safe.
+            let cursor: string | null | undefined;
+            let found = false;
+            do {
+                const response = await peer.request<{ data: Array<{ id: string }>; nextCursor?: string | null }>(
+                    'thread/list', { archived, limit: 100, cursor }, 15_000,
+                );
+                found = response.data.some(thread => thread.id === threadId);
+                cursor = response.nextCursor;
+            } while (!found && cursor);
+            if (!found) {
+                try {
+                    await peer.request(archived ? 'thread/archive' : 'thread/unarchive', { threadId }, 20_000);
+                } catch (error) {
+                    // Missing history is expected only for a new thread with no history-writing commands.
+                    if (archived && binding.emptyNativeSessionIds?.includes(threadId) &&
+                        error instanceof Error && /\bno rollout found\b/i.test(error.message) &&
+                        !listSessionBindings().some(other => other.provider === 'codex' &&
+                            other.nativeSessionIds.includes(threadId) && !other.emptyNativeSessionIds?.includes(threadId))) continue;
+                    throw error;
+                }
+            }
+        }
+    } finally {
+        clearTimeout(timeout);
+        signal?.removeEventListener('abort', abort);
+        await peer.close();
+    }
+}
+
+export type CodexArchiveResult = { success: boolean; stopped: boolean; error?: string };
+
+export async function executeSessionArchive(request: { sessionId: string; nativeSessionId?: string }, signal?: AbortSignal): Promise<CodexArchiveResult> {
+    let stopped = false;
+    try {
+        const binding = readSessionBinding(request.sessionId);
+        // Older CLIs have no durable process identity. Never kill a possibly reused PID.
+        if (!binding) throw new Error('session-identity-unavailable');
+        if (binding.provider !== 'codex') throw new Error('session-provider-mismatch');
+        if (request.nativeSessionId && !binding.nativeSessionIds.includes(request.nativeSessionId)) {
+            throw new Error('native-session-id-unavailable');
+        }
+        // Confirm this session's stop independently of other sessions using its native history.
+        await stopBoundSession(binding, signal);
+        stopped = true;
+        // The final turn can persist another native thread ID during shutdown.
+        const latest = readSessionBinding(request.sessionId) ?? binding;
+        if (latest.provider !== 'codex') throw new Error('session-provider-mismatch');
+        if (isBindingRunning(latest)) {
+            stopped = false;
+            throw new Error('native-session-in-use');
+        }
+        if (binding.nativeSessionIds.some(id => !latest.nativeSessionIds.includes(id))) throw new Error('native-session-id-unavailable');
+        const inUse = listSessionBindings().some(other => other.sessionId !== binding.sessionId &&
+            other.provider === 'codex' && other.nativeSessionIds.some(id => latest.nativeSessionIds.includes(id)) && isBindingRunning(other));
+        if (inUse) throw new Error('native-session-in-use');
+        await syncCodexArchive(latest, true, signal);
+        return { success: true, stopped };
+    } catch (error) {
+        const message = error instanceof Error ? error.message : '';
+        const known = ['session-identity-unavailable', 'session-provider-mismatch', 'native-session-in-use',
+            'native-session-id-unavailable', 'stop-not-confirmed', 'process-verification-unsupported'];
+        return { success: false, stopped,
+            error: known.includes(message) ? message : stopped ? 'native-archive-failed' : 'stop-failed' };
+    }
+}
+
+export async function restoreCodexSession(nativeSessionId: string): Promise<string | undefined> {
+    const bindings = listSessionBindings().filter(binding => binding.provider === 'codex' && binding.nativeSessionIds.includes(nativeSessionId));
+    if (!bindings.length) throw new Error('session-identity-unavailable');
+    if (bindings.some(isBindingRunning)) throw new Error('native-session-in-use');
+    const binding = bindings[0];
+    await stopBoundSession(binding);
+    await syncCodexArchive({ ...binding, nativeSessionIds: [nativeSessionId] }, false);
+    return binding.codexHome;
+}

--- a/packages/happy-cli/src/daemon/sessionBinding.test.ts
+++ b/packages/happy-cli/src/daemon/sessionBinding.test.ts
@@ -1,0 +1,87 @@
+import { spawn, type ChildProcess } from 'node:child_process';
+import { once } from 'node:events';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const home = vi.hoisted(() => ({ value: '' }));
+vi.mock('@/configuration', () => ({ configuration: { get happyHomeDir() { return home.value; } } }));
+vi.mock('@/ui/logger', () => ({ logger: { debug: vi.fn() } }));
+vi.mock('@/codex/appserver/CodexJsonRpcPeer', () => ({ CodexJsonRpcPeer: vi.fn() }));
+import { isBindingRunning, processIdentity, processStart, readSessionBinding, readStopSnapshot, writeStopSnapshot, recordSessionBinding, recordNativeThreadEmpty, type SessionBinding } from './sessionBinding';
+import { stopBoundSession } from './executeSessionArchive';
+import type { Metadata } from '@/api/types';
+
+describe.skipIf(process.platform === 'win32')('verified session process binding', () => {
+    const children: ChildProcess[] = [];
+    afterEach(() => {
+        vi.unstubAllEnvs();
+        for (const child of children.splice(0)) if (child.exitCode === null && child.signalCode === null) child.kill('SIGKILL');
+        if (home.value) rmSync(home.value, { recursive: true, force: true });
+    });
+
+    async function fixture() {
+        home.value = mkdtempSync(join(tmpdir(), 'happy-archive-test-'));
+        recordSessionBinding('isolated', { path: home.value, flavor: 'codex', codexSessionId: 'native-1' } as Metadata);
+        const child = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1000)'], { stdio: 'ignore' });
+        children.push(child);
+        await once(child, 'spawn');
+        const binding: SessionBinding = { ...readSessionBinding('isolated')!, pid: child.pid!, identity: processIdentity(child.pid!)! };
+        return { child, binding };
+    }
+
+    it('stops an isolated real process and persists a retry snapshot', async () => {
+        const { child, binding } = await fixture();
+        expect(isBindingRunning(binding)).toBe(true);
+        await stopBoundSession(binding);
+        expect(isBindingRunning(binding)).toBe(false);
+        expect(child.signalCode).toBe('SIGTERM');
+        const snapshot = readStopSnapshot(binding).find(entry => entry.pid === binding.pid);
+        expect(processStart(snapshot!.identity)).toBe(processStart(binding.identity));
+        await stopBoundSession(binding);
+    });
+
+    it('never signals a reused PID with a different identity', async () => {
+        const { binding } = await fixture();
+        await stopBoundSession({ ...binding, identity: 'different-process S' });
+        expect(isBindingRunning(binding)).toBe(true);
+    });
+
+    it('retains all native IDs belonging to one Happy session', () => {
+        home.value = mkdtempSync(join(tmpdir(), 'happy-archive-test-'));
+        for (const id of ['native-1', 'native-2', 'native-1']) {
+            recordSessionBinding('isolated', { path: home.value, flavor: 'codex', codexSessionId: id } as Metadata);
+        }
+        expect(readSessionBinding('isolated')?.nativeSessionIds).toEqual(['native-1', 'native-2']);
+    });
+    it('preserves empty-thread evidence across metadata updates and clears it before use', () => {
+        home.value = mkdtempSync(join(tmpdir(), 'happy-empty-thread-'));
+        const metadata = { path: home.value, flavor: 'codex' } as Metadata;
+        recordSessionBinding('isolated', metadata);
+        recordNativeThreadEmpty('empty', true);
+        recordSessionBinding('isolated', { ...metadata, codexSessionId: 'empty' });
+        expect(readSessionBinding('isolated')).toMatchObject({ nativeSessionIds: ['empty'], emptyNativeSessionIds: ['empty'] });
+        recordNativeThreadEmpty('empty', false);
+        recordSessionBinding('isolated', { ...metadata, codexSessionId: 'next' });
+        expect(readSessionBinding('isolated')).toMatchObject({ nativeSessionIds: ['empty', 'next'], emptyNativeSessionIds: [] });
+    });
+    it('records an absolute Codex home even when the environment uses a relative path', () => {
+        home.value = mkdtempSync(join(tmpdir(), 'happy-archive-home-'));
+        vi.stubEnv('CODEX_HOME', '../codex-history');
+        recordSessionBinding('isolated', { path: home.value, flavor: 'codex', codexSessionId: 'native-1' } as Metadata);
+        expect(readSessionBinding('isolated')?.codexHome).toBe(resolve('../codex-history'));
+    });
+    it.each(['claude', 'gemini'])('does not record %s bindings for native Codex archive', flavor => {
+        home.value = mkdtempSync(join(tmpdir(), 'happy-archive-home-'));
+        recordSessionBinding('unrelated', { path: home.value, flavor } as Metadata);
+        expect(readSessionBinding('unrelated')).toBeNull();
+    });
+    it('stops an orphaned native helper from the persisted snapshot before reconciliation', async () => {
+        const { binding } = await fixture();
+        const deadWrapper = { ...binding, identity: 'previous-wrapper S' };
+        writeStopSnapshot(deadWrapper, [{ pid: binding.pid, identity: binding.identity }]);
+        await stopBoundSession(deadWrapper);
+        expect(isBindingRunning(binding)).toBe(false);
+    });
+});

--- a/packages/happy-cli/src/daemon/sessionBinding.ts
+++ b/packages/happy-cli/src/daemon/sessionBinding.ts
@@ -1,0 +1,148 @@
+import { mkdirSync, readFileSync, readdirSync, renameSync, writeFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { homedir } from 'node:os';
+import { execFileSync } from 'node:child_process';
+import { z } from 'zod';
+import { configuration } from '@/configuration';
+import type { Metadata } from '@/api/types';
+import { logger } from '@/ui/logger';
+import { CODEX_PACKAGE } from '@/codex/package';
+
+const BindingSchema = z.object({
+    sessionId: z.string(), provider: z.enum(['claude', 'codex', 'gemini']),
+    cwd: z.string(), pid: z.number(), identity: z.string(),
+    nativeSessionIds: z.array(z.string()), codexHome: z.string().optional(),
+    emptyNativeSessionIds: z.array(z.string()).optional(),
+    codexPackage: z.string().optional(),
+    processes: z.array(z.object({ pid: z.number(), identity: z.string() })).default([]),
+});
+export type SessionBinding = z.infer<typeof BindingSchema>;
+const directory = () => join(configuration.happyHomeDir, 'session-bindings');
+const file = (id: string) => {
+    if (!/^[a-zA-Z0-9_-]+$/.test(id)) throw new Error('invalid-session-id');
+    return join(directory(), `${id}.json`);
+};
+
+export function processIdentity(pid: number): string | null {
+    if (!Number.isSafeInteger(pid) || pid <= 1) throw new Error('invalid-process-id');
+    if (process.platform === 'win32') throw new Error('process-verification-unsupported');
+    if (process.platform === 'linux') {
+        try {
+            const stat = readFileSync(`/proc/${pid}/stat`, 'utf8');
+            const fields = stat.slice(stat.lastIndexOf(')') + 2).split(' ');
+            const boot = readFileSync('/proc/sys/kernel/random/boot_id', 'utf8').trim();
+            return `${boot}:${fields[19]} ${fields[0]}`;
+        } catch (error) {
+            if ((error as NodeJS.ErrnoException).code === 'ENOENT') return null;
+            throw error;
+        }
+    }
+    try {
+        return execFileSync('ps', ['-p', String(pid), '-o', 'lstart=,stat='], { encoding: 'utf8', timeout: 5000 }).trim() || null;
+    } catch (error) {
+        if ((error as { status?: number }).status === 1) return null;
+        throw error;
+    }
+}
+
+export function processStart(identity: string): string {
+    return identity.replace(/\s+\S+$/, '');
+}
+
+export function isBindingRunning(binding: Pick<SessionBinding, 'pid' | 'identity'>): boolean {
+    const identity = processIdentity(binding.pid);
+    return !!identity && !/\sZ\S*$/.test(identity) && processStart(identity) === processStart(binding.identity);
+}
+
+export function readSessionBinding(id: string): SessionBinding | null {
+    try { return BindingSchema.parse(JSON.parse(readFileSync(file(id), 'utf8'))); }
+    catch (error) {
+        if ((error as NodeJS.ErrnoException).code === 'ENOENT') return null;
+        throw error;
+    }
+}
+
+export function listSessionBindings(): SessionBinding[] {
+    try { return readdirSync(directory()).filter(name => name.endsWith('.json')).flatMap(name => {
+        const binding = readSessionBinding(name.slice(0, -5));
+        return binding ? [binding] : [];
+    }); } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === 'ENOENT') return [];
+        throw error;
+    }
+}
+
+const StopSnapshotSchema = z.object({ identity: z.string(), processes: z.array(z.object({ pid: z.number(), identity: z.string() })) });
+export function readStopSnapshot(binding: SessionBinding) {
+    try {
+        const snapshot = StopSnapshotSchema.parse(JSON.parse(readFileSync(`${file(binding.sessionId)}.stop`, 'utf8')));
+        return processStart(snapshot.identity) === processStart(binding.identity) ? snapshot.processes : [];
+    } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === 'ENOENT') return [];
+        throw error;
+    }
+}
+
+export function writeStopSnapshot(binding: SessionBinding, processes: Array<{ pid: number; identity: string }>) {
+    const target = `${file(binding.sessionId)}.stop`;
+    const temporary = `${target}.${process.pid}.tmp`;
+    writeFileSync(temporary, JSON.stringify({ identity: binding.identity, processes }), { mode: 0o600 });
+    renameSync(temporary, target);
+}
+
+let ownIdentity: string | null = null;
+let currentSession: { id: string; metadata: Metadata } | null = null;
+const managedProcesses = new Map<number, string>();
+
+// Clear this evidence before any mutating command can persist history, including failed RPCs.
+export function recordNativeThreadEmpty(threadId: string, empty: boolean): void {
+    if (!currentSession) return;
+    const binding = readSessionBinding(currentSession.id);
+    if (!binding) return;
+    const ids = new Set(binding.emptyNativeSessionIds ?? []);
+    if (empty) ids.add(threadId);
+    else if (!ids.delete(threadId)) return;
+    binding.emptyNativeSessionIds = [...ids];
+    binding.nativeSessionIds = [...new Set([...binding.nativeSessionIds, threadId])];
+    const target = file(binding.sessionId);
+    const temporary = `${target}.${process.pid}.tmp`;
+    writeFileSync(temporary, JSON.stringify(binding), { mode: 0o600 });
+    renameSync(temporary, target);
+}
+
+export function recordManagedProcess(pid: number | undefined): void {
+    if (!pid || !currentSession) return;
+    try {
+        const identity = processIdentity(pid);
+        if (identity) managedProcesses.set(pid, identity);
+        recordSessionBinding(currentSession.id, currentSession.metadata);
+    } catch (error) { logger.debug('[SessionBinding] Could not record child process', error); }
+}
+
+export function recordSessionBinding(sessionId: string, metadata: Metadata): void {
+    if (metadata.flavor !== 'codex') return;
+    currentSession = { id: sessionId, metadata };
+    try {
+        const provider = 'codex';
+        ownIdentity ??= processIdentity(process.pid);
+        if (!ownIdentity) return;
+        const previous = readSessionBinding(sessionId);
+        const nativeId = metadata.codexSessionId;
+        const binding: SessionBinding = {
+            sessionId, provider, cwd: metadata.path, pid: process.pid, identity: ownIdentity,
+            nativeSessionIds: [...new Set([...(previous?.nativeSessionIds ?? []), ...(nativeId ? [nativeId] : [])])],
+            emptyNativeSessionIds: previous?.emptyNativeSessionIds,
+            processes: [...managedProcesses].map(([pid, identity]) => ({ pid, identity })),
+            codexPackage: CODEX_PACKAGE,
+            codexHome: resolve(process.env.CODEX_HOME || join(homedir(), '.codex')),
+        };
+        if (JSON.stringify(binding) === JSON.stringify(previous)) return;
+        mkdirSync(directory(), { recursive: true, mode: 0o700 });
+        const target = file(sessionId);
+        const temporary = `${target}.${process.pid}.tmp`;
+        writeFileSync(temporary, JSON.stringify(binding), { mode: 0o600 });
+        renameSync(temporary, target);
+    } catch (error) {
+        logger.debug('[SessionBinding] Could not persist session identity', error);
+    }
+}

--- a/packages/happy-server/sources/app/api/socket/rpcHandler.test.ts
+++ b/packages/happy-server/sources/app/api/socket/rpcHandler.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { Socket } from 'socket.io';
+
+vi.mock('@/app/events/eventRouter', () => ({ eventRouter: {} }));
+vi.mock('@/utils/log', () => ({ log: vi.fn() }));
+vi.mock('@/app/share/accessControl', () => ({ checkSessionAccess: vi.fn() }));
+vi.mock('@/storage/db', () => ({ db: {} }));
+vi.mock('@/app/presence/sessionTurnRuntime', () => ({ updateThinkingState: vi.fn(() => ({ turnEnded: false })) }));
+vi.mock('@/app/session/pendingMessageAutoDispatch', () => ({ dispatchNextPendingIfPossible: vi.fn() }));
+import { rpcHandler } from './rpcHandler';
+
+describe('RPC native history timeouts', () => {
+    it.each([
+        ['machine:codex-archive-session', 110000],
+        ['machine:codex-fork-session', 110000],
+        ['machine:codex-duplicate-session', 110000],
+        ['session:killSession', 30000],
+        ['machine:claude-fork-session', 30000],
+    ])('uses the scoped timeout for %s', async (method, timeout) => {
+        const handlers = new Map<string, (...args: any[]) => unknown>();
+        const socket = { on: (name: string, handler: (...args: any[]) => unknown) => handlers.set(name, handler) } as unknown as Socket;
+        const target = { connected: true, timeout: vi.fn().mockReturnThis(), emitWithAck: vi.fn().mockResolvedValue('encrypted-result') };
+        rpcHandler('owner', socket, new Map([[method, target as unknown as Socket]]));
+        const callback = vi.fn();
+        await handlers.get('rpc-call')!({ method, params: 'encrypted-params' }, callback);
+        expect(target.timeout).toHaveBeenCalledWith(timeout);
+        expect(target.emitWithAck).toHaveBeenCalledWith('rpc-request', { method, params: 'encrypted-params' });
+        expect(callback).toHaveBeenCalledWith({ ok: true, result: 'encrypted-result' });
+    });
+});

--- a/packages/happy-server/sources/app/api/socket/rpcHandler.ts
+++ b/packages/happy-server/sources/app/api/socket/rpcHandler.ts
@@ -180,7 +180,10 @@ export function rpcHandler(userId: string, socket: Socket, rpcListeners: Map<str
 
             // Forward the RPC request to the target socket using emitWithAck
             try {
-                const response = await targetSocket.timeout(30000).emitWithAck('rpc-request', {
+                // Codex native history operations may include process shutdown and app-server startup.
+                const nativeHistory = [':codex-archive-session', ':codex-fork-session', ':codex-duplicate-session']
+                    .some(suffix => method.endsWith(suffix));
+                const response = await targetSocket.timeout(nativeHistory ? 110000 : 30000).emitWithAck('rpc-request', {
                     method,
                     params
                 });


### PR DESCRIPTION
## Summary
- Synchronize the existing Happy archive action with Codex native thread archival while preserving Claude and Gemini behavior.
- Record private session/process bindings, verify process identities before stopping, and serialize native archive/restore operations through the daemon.
- Restore archived native history before native app-server fork, propagating the original CODEX_HOME. Preserve main's native fork validation, pagination, and bounded session termination cleanup.
- Keep archived sessions out of active views, report native failures separately with retry support, and add scoped RPC timeout handling and translations.
- Merge upstream main and resolve all three conflicts. Remove docs/session-archive.md; deployment notes and limitations are retained here.

## Validation
Rerun after conflict resolution:
- 231 targeted tests passed: CLI 168, app 58, server 5.
- App and CLI type checking passed; server build/type checking passed after regenerating the Prisma client for main's updated schema.
- CLI build passed; happy-wire build and type checking passed.
- Staged diff whitespace checks passed.
- Non-blocking existing build/config warnings remain (CLI packaging and unrelated Astro tsconfig resolution).

## Remaining Verification
- Real Codex native archive followed by resuming the same Happy history entry still requires end-to-end verification on a disposable session. Native integration tests were not run in this update.

## Deployment Notes and Limitations
- Upgrade the app and CLI, restart the daemon, and deploy the scoped server RPC timeout update. This feature adds no database schema changes.
- Older sessions without private bindings cannot be natively archived. Windows process verification is currently unsupported.
- Native failures do not undo Happy's confirmed stop. Retry requires an online machine; there is no durable retry queue.
- Known live Happy sessions sharing native history block archival; independent native CLI clients must be stopped separately.
- A lost RPC response can leave completion uncertain; retries check the target state first.
