### PR TITLE
fix(app): add GitHub navigation to desktop and web

### DIFF
--- a/packages/happy-app/sources/app/(app)/_layout.tsx
+++ b/packages/happy-app/sources/app/(app)/_layout.tsx
@@ -68,6 +68,13 @@ export default function RootLayout() {
                 }}
             />
             <Stack.Screen
+                name="github/index"
+                options={{
+                    headerShown: true,
+                    headerTitle: t('tabs.github'),
+                }}
+            />
+            <Stack.Screen
                 name="inbox/notice/[id]"
                 options={{
                     headerShown: true,

--- a/packages/happy-app/sources/app/(app)/github/index.tsx
+++ b/packages/happy-app/sources/app/(app)/github/index.tsx
@@ -1,0 +1,42 @@
+import * as React from 'react';
+import { Pressable, Text, View } from 'react-native';
+import { Stack } from 'expo-router';
+import { Ionicons } from '@expo/vector-icons';
+import { useUnistyles } from 'react-native-unistyles';
+import { GitHubListView } from '@/components/GitHubListView';
+import { Typography } from '@/constants/Typography';
+import { t } from '@/text';
+
+export default function GitHubPage() {
+    const { theme } = useUnistyles();
+    const [repo, setRepo] = React.useState<string | null>(null);
+    const repoPickerTriggerRef = React.useRef<(() => void) | null>(null);
+    const title = repo ? repo.split('/').pop() || repo : t('github.allRepos');
+
+    return (
+        <View style={{ flex: 1 }}>
+            <Stack.Screen
+                options={{
+                    headerTitle: () => (
+                        <Pressable
+                            accessibilityRole="button"
+                            accessibilityLabel={repo || title}
+                            onPress={() => repoPickerTriggerRef.current?.()}
+                            hitSlop={10}
+                            style={{ flexDirection: 'row', alignItems: 'center', maxWidth: '100%' }}
+                        >
+                            <Text
+                                numberOfLines={1}
+                                style={{ maxWidth: 200, flexShrink: 1, fontSize: 17, color: theme.colors.header.tint, ...Typography.default('semiBold') }}
+                            >
+                                {title}
+                            </Text>
+                            <Ionicons name="chevron-down" size={13} color={theme.colors.textSecondary} style={{ marginLeft: 4 }} />
+                        </Pressable>
+                    ),
+                }}
+            />
+            <GitHubListView onRepoChange={setRepo} repoPickerTriggerRef={repoPickerTriggerRef} />
+        </View>
+    );
+}

--- a/packages/happy-app/sources/components/GitHubNavigation.test.ts
+++ b/packages/happy-app/sources/components/GitHubNavigation.test.ts
@@ -1,0 +1,26 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, test } from 'vitest';
+
+describe('GitHub desktop and web navigation', () => {
+    test.each(['components/SidebarView.tsx', 'desktop/DesktopWindowFrame.tsx'])(
+        '%s exposes the connected GitHub integration',
+        (file) => {
+            const source = readFileSync(join(__dirname, '..', file), 'utf8');
+            expect(source).toContain('const profile = useProfile()');
+            expect(source).toContain('{!!profile.github && (');
+            expect(source).toContain("accessibilityLabel={t('tabs.github')}");
+            expect(source).toContain("router.navigate('/(app)/github')");
+            expect(source).toContain("require('@/assets/images/navigation/github.png')");
+        },
+    );
+
+    test('registers a standalone list route with repository selection', () => {
+        const layout = readFileSync(join(__dirname, '../app/(app)/_layout.tsx'), 'utf8');
+        const page = readFileSync(join(__dirname, '../app/(app)/github/index.tsx'), 'utf8');
+        expect(layout).toContain('name="github/index"');
+        expect(page).toContain('<GitHubListView onRepoChange={setRepo} repoPickerTriggerRef={repoPickerTriggerRef} />');
+        expect(page).toContain('repoPickerTriggerRef.current?.()');
+        expect(existsSync(join(__dirname, '../assets/images/navigation/github.png'))).toBe(true);
+    });
+});

--- a/packages/happy-app/sources/components/SidebarView.tsx
+++ b/packages/happy-app/sources/components/SidebarView.tsx
@@ -15,7 +15,7 @@ import { Image } from 'expo-image';
 import { StyleSheet, useUnistyles } from 'react-native-unistyles';
 import { t } from '@/text';
 import { useInboxHasContent } from '@/hooks/useInboxHasContent';
-import { useDootaskProfile } from '@/sync/storage';
+import { useDootaskProfile, useProfile } from '@/sync/storage';
 import { Ionicons } from '@expo/vector-icons';
 import { requestCommandPalette } from './CommandPalette/events';
 import { getDesktopPlatform, handleDesktopTitleBarMouseDown } from '@/desktop/desktopWindowUtils';
@@ -74,6 +74,7 @@ const stylesheet = StyleSheet.create((theme, runtime) => ({
     },
     titleContainerLeft: {
         flex: 1,
+        minWidth: 0,
         flexDirection: 'column',
         alignItems: 'flex-start',
         marginLeft: 4,
@@ -88,6 +89,7 @@ const stylesheet = StyleSheet.create((theme, runtime) => ({
         gap: 6,
     },
     titleText: {
+        maxWidth: '100%',
         fontSize: 17,
         fontWeight: '500',
         color: theme.colors.header.tint,
@@ -103,6 +105,7 @@ const stylesheet = StyleSheet.create((theme, runtime) => ({
         marginRight: 4,
     },
     statusText: {
+        flexShrink: 1,
         fontSize: 11,
         fontWeight: '500',
         lineHeight: 16,
@@ -179,6 +182,7 @@ export const SidebarView = React.memo((props: SidebarViewProps) => {
     const friendRequests = useFriendRequests();
     const inboxHasContent = useInboxHasContent();
     const dootaskProfile = useDootaskProfile();
+    const profile = useProfile();
     const [isSearchHovered, setIsSearchHovered] = React.useState(false);
     const desktopPlatform = getDesktopPlatform();
     const isDesktopMacOS = desktopPlatform === 'macos';
@@ -309,7 +313,7 @@ export const SidebarView = React.memo((props: SidebarViewProps) => {
                         size={6}
                         style={styles.statusDot}
                     />
-                    <Text style={[styles.statusText, { color: connectionStatus.textColor }]}>
+                    <Text numberOfLines={1} style={[styles.statusText, { color: connectionStatus.textColor }]}>
                         {connectionStatus.text}
                     </Text>
                 </View>
@@ -354,6 +358,27 @@ export const SidebarView = React.memo((props: SidebarViewProps) => {
                 >
                     <Image
                         source={require('@/assets/images/navigation/todo.png')}
+                        contentFit="contain"
+                        style={{ width: 20, height: 20, margin: 4, opacity: isDesktopMacOS ? 0.62 : 1 }}
+                        tintColor={theme.colors.header.tint}
+                    />
+                </Pressable>
+            )}
+            {!!profile.github && (
+                <Pressable
+                    accessibilityLabel={t('tabs.github')}
+                    accessibilityRole="button"
+                    onPress={() => router.navigate('/(app)/github')}
+                    hitSlop={10}
+                    ref={(element: any) => {
+                        if (element && typeof element === 'object') {
+                            element.title = t('tabs.github');
+                        }
+                    }}
+                    style={isDesktopMacOS ? styles.desktopNavigationButton : undefined}
+                >
+                    <Image
+                        source={require('@/assets/images/navigation/github.png')}
                         contentFit="contain"
                         style={{ width: 20, height: 20, margin: 4, opacity: isDesktopMacOS ? 0.62 : 1 }}
                         tintColor={theme.colors.header.tint}

--- a/packages/happy-app/sources/desktop/DesktopWindowFrame.tsx
+++ b/packages/happy-app/sources/desktop/DesktopWindowFrame.tsx
@@ -8,7 +8,7 @@ import { useUnistyles } from 'react-native-unistyles';
 
 import { useAuth } from '@/auth/AuthContext';
 import { useInboxHasContent } from '@/hooks/useInboxHasContent';
-import { useDootaskProfile, useFriendRequests, useSocketStatus } from '@/sync/storage';
+import { useDootaskProfile, useFriendRequests, useProfile, useSocketStatus } from '@/sync/storage';
 import { getServerInfo } from '@/sync/serverConfig';
 import { t } from '@/text';
 import { StatusDot } from '@/components/StatusDot';
@@ -135,6 +135,7 @@ function WindowsTitleBarNavigation() {
     const friendRequests = useFriendRequests();
     const inboxHasContent = useInboxHasContent();
     const dootaskProfile = useDootaskProfile();
+    const profile = useProfile();
     const { width: windowWidth } = useWindowDimensions();
     const showConnectionText = windowWidth >= 720;
 
@@ -218,6 +219,19 @@ function WindowsTitleBarNavigation() {
                 >
                     <Image
                         source={require('@/assets/images/navigation/todo.png')}
+                        contentFit="contain"
+                        style={{ height: 18, width: 18 }}
+                        tintColor={theme.colors.header.tint}
+                    />
+                </WindowsNavigationButton>
+            )}
+            {!!profile.github && (
+                <WindowsNavigationButton
+                    accessibilityLabel={t('tabs.github')}
+                    onPress={() => router.navigate('/(app)/github')}
+                >
+                    <Image
+                        source={require('@/assets/images/navigation/github.png')}
                         contentFit="contain"
                         style={{ height: 18, width: 18 }}
                         tintColor={theme.colors.header.tint}


### PR DESCRIPTION
## Summary
- Add connected GitHub navigation alongside DooTask in the web/macOS sidebar and Windows title bar.
- Add a standalone GitHub list route with repository selection.
- Constrain sidebar title and status text for narrow layouts.

## Validation
- `yarn typecheck` in `packages/happy-app`: passed.
- Focused Vitest checks: 3 files, 8 tests passed.
- `git diff --check`: passed for changed app files.
- Authenticated UI interactions have not been manually verified.

## Scope
- Local server environment changes are excluded.